### PR TITLE
feat(rpc): implement Protobuf-based RPC for cross-runtime agent metho…

### DIFF
--- a/docs/ORLEANS_RPC_DESIGN.md
+++ b/docs/ORLEANS_RPC_DESIGN.md
@@ -1,0 +1,1100 @@
+# Orleans Agent RPC 方法调用设计方案
+
+## 问题背景
+
+当前 Orleans 模式下，客户端只能通过 `HandleEventAsync` 发送事件到 Silo，无法直接调用 Agent 接口定义的业务方法。这导致：
+
+1. **易用性低**：简单的读取操作也需要设计请求/响应事件
+2. **开发效率低**：无法复用 Agent 接口定义的方法签名
+3. **类型不安全**：事件参数和返回值需要手动序列化/反序列化
+
+## 设计目标
+
+1. **支持调用 Agent 接口方法**：客户端可以调用 `IMyAgent.GetDataAsync()` 等方法
+2. **类型安全**：编译时检查参数和返回值类型
+3. **高性能**：最小化序列化开销
+4. **向后兼容**：不破坏现有的事件驱动模式
+
+## 方案设计
+
+### 方案一：通用 RPC 方法（推荐）
+
+#### 1. 扩展 IGAgentGrain 接口
+
+```csharp
+public interface IGAgentGrain : IGrainWithStringKey
+{
+    // ... 现有方法 ...
+
+    /// <summary>
+    /// 通用方法调用 - 支持调用 Agent 接口定义的任意方法
+    /// </summary>
+    /// <param name="methodName">方法名</param>
+    /// <param name="argsJson">参数 JSON 序列化</param>
+    /// <returns>返回值 JSON 序列化</returns>
+    Task<string?> InvokeMethodAsync(string methodName, string? argsJson);
+
+    /// <summary>
+    /// 通用方法调用 - Protobuf 序列化版本（高性能）
+    /// </summary>
+    /// <param name="methodName">方法名</param>
+    /// <param name="argsBytes">参数 Protobuf 序列化</param>
+    /// <returns>返回值 Protobuf 序列化</returns>
+    Task<byte[]?> InvokeMethodBytesAsync(string methodName, byte[]? argsBytes);
+}
+```
+
+#### 2. OrleansGAgentGrain 实现
+
+```csharp
+public partial class OrleansGAgentGrain
+{
+    public async Task<string?> InvokeMethodAsync(string methodName, string? argsJson)
+    {
+        if (_agent == null)
+            throw new InvalidOperationException("Agent not initialized");
+
+        // 查找方法
+        var method = _agent.GetType().GetMethod(methodName, 
+            BindingFlags.Public | BindingFlags.Instance);
+        
+        if (method == null)
+            throw new InvalidOperationException($"Method '{methodName}' not found");
+
+        // 反序列化参数
+        object?[]? args = null;
+        if (!string.IsNullOrEmpty(argsJson))
+        {
+            var paramInfos = method.GetParameters();
+            args = DeserializeArgs(argsJson, paramInfos);
+        }
+
+        // 调用方法
+        var result = method.Invoke(_agent, args);
+
+        // 处理 async 方法
+        if (result is Task task)
+        {
+            await task;
+            
+            // 获取 Task<T> 的结果
+            var resultProperty = task.GetType().GetProperty("Result");
+            if (resultProperty != null && resultProperty.PropertyType != typeof(void))
+            {
+                var taskResult = resultProperty.GetValue(task);
+                return taskResult != null 
+                    ? JsonSerializer.Serialize(taskResult) 
+                    : null;
+            }
+            return null;
+        }
+
+        return result != null ? JsonSerializer.Serialize(result) : null;
+    }
+
+    private object?[] DeserializeArgs(string argsJson, ParameterInfo[] paramInfos)
+    {
+        var argsArray = JsonSerializer.Deserialize<JsonElement[]>(argsJson);
+        var args = new object?[paramInfos.Length];
+        
+        for (int i = 0; i < paramInfos.Length; i++)
+        {
+            args[i] = JsonSerializer.Deserialize(
+                argsArray[i].GetRawText(), 
+                paramInfos[i].ParameterType);
+        }
+        
+        return args;
+    }
+}
+```
+
+#### 3. OrleansGAgentActor 客户端代理
+
+```csharp
+public class OrleansGAgentActor : IGAgentActor
+{
+    // ... 现有代码 ...
+
+    /// <summary>
+    /// 调用 Agent 方法（泛型版本）
+    /// </summary>
+    public async Task<TResult?> InvokeAsync<TResult>(
+        string methodName, 
+        params object?[] args)
+    {
+        EnsureGrain();
+        
+        var argsJson = args.Length > 0 
+            ? JsonSerializer.Serialize(args) 
+            : null;
+        
+        var resultJson = await _grain!.InvokeMethodAsync(methodName, argsJson);
+        
+        if (string.IsNullOrEmpty(resultJson))
+            return default;
+            
+        return JsonSerializer.Deserialize<TResult>(resultJson);
+    }
+
+    /// <summary>
+    /// 调用无返回值的 Agent 方法
+    /// </summary>
+    public async Task InvokeAsync(string methodName, params object?[] args)
+    {
+        EnsureGrain();
+        
+        var argsJson = args.Length > 0 
+            ? JsonSerializer.Serialize(args) 
+            : null;
+        
+        await _grain!.InvokeMethodAsync(methodName, argsJson);
+    }
+}
+```
+
+#### 4. 使用示例
+
+```csharp
+// PaymentService 中使用
+public class PaymentService : IPaymentService
+{
+    private readonly IGAgentActorFactory _actorFactory;
+
+    public async Task<string?> GetCustomerIdAsync(Guid userId, PaymentPlatform platform)
+    {
+        var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+        
+        // 直接调用 Agent 方法！
+        return await actor.InvokeAsync<string?>(
+            "GetPlatformCustomerIdAsync", 
+            (int)platform);
+    }
+
+    public async Task SetCustomerIdAsync(Guid userId, PaymentPlatform platform, string customerId)
+    {
+        var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+        
+        await actor.InvokeAsync(
+            "SetPlatformCustomerIdAsync", 
+            (int)platform, 
+            customerId);
+    }
+}
+```
+
+---
+
+### 方案二：接口代理（高级）
+
+使用动态代理让 Actor 直接实现 Agent 接口。
+
+#### 1. 定义代理生成器
+
+```csharp
+public static class AgentProxyGenerator
+{
+    /// <summary>
+    /// 创建实现 Agent 接口的代理
+    /// </summary>
+    public static TAgent CreateProxy<TAgent>(IGAgentActor actor) 
+        where TAgent : class, IGAgent
+    {
+        return DispatchProxy.Create<TAgent, AgentMethodProxy<TAgent>>();
+    }
+}
+
+public class AgentMethodProxy<TAgent> : DispatchProxy where TAgent : IGAgent
+{
+    private IGAgentActor _actor = null!;
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod == null)
+            throw new ArgumentNullException(nameof(targetMethod));
+
+        // 调用 Actor 的通用 RPC 方法
+        var task = _actor.InvokeAsync<object>(targetMethod.Name, args ?? []);
+        
+        // 处理返回类型
+        if (targetMethod.ReturnType == typeof(Task))
+        {
+            return task;
+        }
+        
+        if (targetMethod.ReturnType.IsGenericType && 
+            targetMethod.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            // 转换 Task<object> 到 Task<T>
+            var resultType = targetMethod.ReturnType.GetGenericArguments()[0];
+            return ConvertTask(task, resultType);
+        }
+        
+        // 同步方法（不推荐）
+        return task.GetAwaiter().GetResult();
+    }
+}
+```
+
+#### 2. 使用示例
+
+```csharp
+// 获取类型安全的 Agent 代理
+var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+var agentProxy = AgentProxyGenerator.CreateProxy<IPaymentIndexGAgent>(actor);
+
+// 直接调用接口方法！完全类型安全！
+var customerId = await agentProxy.GetPlatformCustomerIdAsync(PaymentPlatform.Stripe);
+await agentProxy.SetPlatformCustomerIdAsync(PaymentPlatform.Stripe, "cus_xxx");
+```
+
+---
+
+### 方案三：Protobuf RPC（高性能）
+
+对于高性能场景，使用 Protobuf 序列化替代 JSON。
+
+#### 1. 定义 RPC 消息
+
+```protobuf
+// agent_rpc.proto
+syntax = "proto3";
+
+package aevatar.agents.rpc;
+
+message MethodInvocation {
+    string method_name = 1;
+    repeated bytes args = 2;  // 每个参数单独序列化
+    map<string, string> metadata = 3;
+}
+
+message MethodResult {
+    bool success = 1;
+    bytes result = 2;
+    string error_message = 3;
+    string error_type = 4;
+}
+```
+
+#### 2. 高性能调用
+
+```csharp
+public async Task<TResult?> InvokeProtobufAsync<TResult>(
+    string methodName, 
+    params IMessage[] args) where TResult : IMessage, new()
+{
+    var invocation = new MethodInvocation
+    {
+        MethodName = methodName
+    };
+    
+    foreach (var arg in args)
+    {
+        invocation.Args.Add(arg.ToByteString());
+    }
+    
+    var resultBytes = await _grain!.InvokeMethodBytesAsync(
+        methodName, 
+        invocation.ToByteArray());
+    
+    if (resultBytes == null || resultBytes.Length == 0)
+        return default;
+    
+    var result = new TResult();
+    result.MergeFrom(resultBytes);
+    return result;
+}
+```
+
+---
+
+## 推荐实现路径
+
+### Phase 1：基础 RPC 支持（方案一）
+
+1. 扩展 `IGAgentGrain` 添加 `InvokeMethodAsync`
+2. 在 `OrleansGAgentGrain` 实现反射调用
+3. 在 `OrleansGAgentActor` 添加 `InvokeAsync<T>` 方法
+4. 添加方法缓存优化性能
+
+### Phase 2：类型安全代理（方案二）
+
+1. 实现 `AgentProxyGenerator`
+2. 支持 `DispatchProxy` 动态代理
+3. 提供 `actor.AsProxy<IMyAgent>()` 扩展方法
+
+### Phase 3：高性能优化（方案三）
+
+1. 支持 Protobuf 序列化
+2. 方法签名缓存
+3. 表达式树替代反射
+
+---
+
+## 安全考虑
+
+1. **方法白名单**：只允许调用标记了 `[AgentRpc]` 的方法
+2. **参数验证**：检查参数类型匹配
+3. **超时控制**：设置 RPC 调用超时
+4. **异常传播**：正确传递异常信息到客户端
+
+```csharp
+// 标记可远程调用的方法
+[AttributeUsage(AttributeTargets.Method)]
+public class AgentRpcAttribute : Attribute
+{
+    public int TimeoutMs { get; set; } = 30000;
+    public bool RequireAuth { get; set; } = false;
+}
+
+// Agent 中使用
+public class PaymentIndexGAgent : GAgentBase<PaymentIndexState>
+{
+    [AgentRpc]
+    public Task<string?> GetPlatformCustomerIdAsync(int platform)
+    {
+        // ...
+    }
+}
+```
+
+---
+
+## 性能优化
+
+1. **方法缓存**：缓存 `MethodInfo` 避免重复反射
+2. **委托缓存**：编译表达式树为委托
+3. **序列化优化**：使用 `System.Text.Json` 源生成器
+4. **连接池**：复用 Grain 引用
+
+```csharp
+// 方法缓存示例
+private static readonly ConcurrentDictionary<(Type, string), MethodInfo> _methodCache = new();
+
+private MethodInfo GetMethod(string methodName)
+{
+    var key = (_agent!.GetType(), methodName);
+    
+    return _methodCache.GetOrAdd(key, k =>
+    {
+        var method = k.Item1.GetMethod(k.Item2, 
+            BindingFlags.Public | BindingFlags.Instance);
+        
+        return method ?? throw new InvalidOperationException(
+            $"Method '{k.Item2}' not found on type '{k.Item1.Name}'");
+    });
+}
+```
+
+---
+
+## 迁移指南
+
+### 从事件驱动迁移到 RPC
+
+**Before (事件驱动)**：
+```csharp
+// 定义请求事件
+var request = new GetCustomerIdRequest { Platform = platform };
+await actor.PublishEventAsync(request);
+// 需要订阅响应事件...复杂！
+```
+
+**After (RPC 调用)**：
+```csharp
+// 直接调用方法
+var customerId = await actor.InvokeAsync<string?>(
+    "GetPlatformCustomerIdAsync", 
+    (int)platform);
+```
+
+---
+
+## 架构说明：代理执行位置
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    HttpApi 进程 (客户端)                      │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │  接口代理 (DispatchProxy / Source Generated)            │ │
+│  │  ┌─────────────────────────────────────────────────────┐│ │
+│  │  │ proxy.GetPlatformCustomerIdAsync(platform)          ││ │
+│  │  │         ↓                                           ││ │
+│  │  │ actor.InvokeAsync("GetPlatformCustomerIdAsync", ...) ││ │
+│  │  │         ↓                                           ││ │
+│  │  │ grain.InvokeMethodAsync(methodName, argsJson)       ││ │
+│  │  └─────────────────────────────────────────────────────┘│ │
+│  └─────────────────────────────────────────────────────────┘ │
+│                           │ RPC                              │
+└───────────────────────────│─────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│                    Silo 进程 (服务端)                         │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │  OrleansGAgentGrain                                     │ │
+│  │  ┌─────────────────────────────────────────────────────┐│ │
+│  │  │ InvokeMethodAsync(methodName, argsJson)             ││ │
+│  │  │         ↓                                           ││ │
+│  │  │ _agent.GetPlatformCustomerIdAsync(platform)         ││ │  ← 真正执行
+│  │  │         ↓                                           ││ │
+│  │  │ return State.PlatformCustomers[platform]            ││ │
+│  │  └─────────────────────────────────────────────────────┘│ │
+│  └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**关键点**：接口代理只是**客户端存根（Stub）**，类似 gRPC Client Stub。业务逻辑始终在 Silo 执行。
+
+---
+
+## 方案对比分析
+
+| 维度 | 方案一：通用 RPC | 方案二：接口代理 | 方案三：Protobuf RPC |
+|------|------------------|------------------|----------------------|
+| **易用性** | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
+| **类型安全** | ⭐⭐ (字符串方法名) | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| **编译检查** | ❌ | ✅ | ✅ |
+| **序列化性能** | ⭐⭐⭐ (JSON) | ⭐⭐⭐ (JSON) | ⭐⭐⭐⭐⭐ (Protobuf) |
+| **运行时开销** | 低 | 中 (DispatchProxy反射) | 低 |
+| **实现复杂度** | 低 | 中 | 高 |
+| **维护成本** | 低 | 低 | 高 (需维护 proto) |
+
+---
+
+## 🏆 推荐方案：Source Generator + Protobuf
+
+**综合最优方案**：使用 **C# Source Generator** 编译时生成代理 + **Protobuf** 高性能序列化。
+
+### 为什么是最优？
+
+| 优势 | 说明 |
+|------|------|
+| ✅ **类型安全** | 编译时生成，有完整的类型检查 |
+| ✅ **零运行时反射** | 代理代码在编译时生成 |
+| ✅ **高性能序列化** | Protobuf 二进制序列化，比 JSON 快 5-10x |
+| ✅ **易用性高** | 使用体验与直接调用接口相同 |
+| ✅ **IDE 支持** | IntelliSense、重构、跳转定义全支持 |
+| ✅ **版本兼容** | Protobuf 天然支持前后向兼容 |
+
+---
+
+### 架构设计
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        编译时 (Build Time)                        │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │  Source Generator                                           │ │
+│  │  ├── 扫描 [AgentRpc] 标记的接口                               │ │
+│  │  ├── 生成 RPC 请求/响应 Protobuf 消息                         │ │
+│  │  └── 生成类型安全的 Proxy 类                                  │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ↓
+┌─────────────────────────────────────────────────────────────────┐
+│                        运行时 (Runtime)                           │
+│                                                                   │
+│  HttpApi 进程                          Silo 进程                  │
+│  ┌─────────────────┐                  ┌─────────────────────────┐ │
+│  │ Proxy (生成的)   │   Protobuf RPC   │ OrleansGAgentGrain      │ │
+│  │ ┌─────────────┐ │  ─────────────►  │ ┌─────────────────────┐ │ │
+│  │ │ Serialize   │ │                  │ │ Deserialize Args    │ │ │
+│  │ │ Args → bytes│ │                  │ │ Invoke Agent Method │ │ │
+│  │ └─────────────┘ │  ◄─────────────  │ │ Serialize Result    │ │ │
+│  │ ┌─────────────┐ │   Protobuf Resp  │ └─────────────────────┘ │ │
+│  │ │ Deserialize │ │                  └─────────────────────────┘ │
+│  │ │ Result      │ │                                              │
+│  │ └─────────────┘ │                                              │
+│  └─────────────────┘                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Step 1: 定义 RPC Proto 消息
+
+```protobuf
+// agent_rpc.proto
+syntax = "proto3";
+
+package aevatar.agents.rpc;
+
+option csharp_namespace = "Aevatar.Agents.Rpc";
+
+import "google/protobuf/any.proto";
+
+// RPC 方法调用请求
+message RpcRequest {
+    string method_name = 1;
+    repeated google.protobuf.Any args = 2;
+    map<string, string> metadata = 3;
+    string correlation_id = 4;
+}
+
+// RPC 方法调用响应
+message RpcResponse {
+    bool success = 1;
+    google.protobuf.Any result = 2;
+    RpcError error = 3;
+    string correlation_id = 4;
+}
+
+// RPC 错误信息
+message RpcError {
+    string error_type = 1;
+    string message = 2;
+    string stack_trace = 3;
+}
+```
+
+---
+
+### Step 2: 扩展 IGAgentGrain 接口
+
+```csharp
+public interface IGAgentGrain : IGrainWithStringKey
+{
+    // ... 现有方法 ...
+
+    /// <summary>
+    /// Protobuf RPC 方法调用
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest 序列化字节</param>
+    /// <returns>RpcResponse 序列化字节</returns>
+    Task<byte[]> InvokeRpcAsync(byte[] requestBytes);
+}
+```
+
+---
+
+### Step 3: OrleansGAgentGrain 实现
+
+```csharp
+public partial class OrleansGAgentGrain
+{
+    // 方法缓存 - 避免重复反射
+    private static readonly ConcurrentDictionary<(Type, string), MethodInfo> _methodCache = new();
+    
+    public async Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
+    {
+        var request = RpcRequest.Parser.ParseFrom(requestBytes);
+        var response = new RpcResponse { CorrelationId = request.CorrelationId };
+        
+        try
+        {
+            if (_agent == null)
+                throw new InvalidOperationException("Agent not initialized");
+
+            // 获取方法（带缓存）
+            var method = GetCachedMethod(request.MethodName);
+            
+            // 验证方法是否允许 RPC 调用
+            ValidateRpcMethod(method);
+            
+            // 反序列化参数
+            var args = DeserializeProtobufArgs(request.Args, method.GetParameters());
+            
+            // 调用方法
+            var result = method.Invoke(_agent, args);
+            
+            // 处理 async 方法
+            if (result is Task task)
+            {
+                await task;
+                result = GetTaskResult(task);
+            }
+            
+            // 序列化返回值
+            if (result != null)
+            {
+                response.Result = PackResult(result);
+            }
+            response.Success = true;
+        }
+        catch (Exception ex)
+        {
+            response.Success = false;
+            response.Error = new RpcError
+            {
+                ErrorType = ex.GetType().FullName,
+                Message = ex.Message,
+                StackTrace = ex.StackTrace
+            };
+            _logger.LogError(ex, "RPC method {Method} failed", request.MethodName);
+        }
+        
+        return response.ToByteArray();
+    }
+    
+    private MethodInfo GetCachedMethod(string methodName)
+    {
+        var key = (_agent!.GetType(), methodName);
+        return _methodCache.GetOrAdd(key, k =>
+        {
+            var method = k.Item1.GetMethod(k.Item2, 
+                BindingFlags.Public | BindingFlags.Instance);
+            return method ?? throw new InvalidOperationException(
+                $"Method '{k.Item2}' not found on '{k.Item1.Name}'");
+        });
+    }
+    
+    private void ValidateRpcMethod(MethodInfo method)
+    {
+        // 检查是否有 [AgentRpc] 特性
+        var rpcAttr = method.GetCustomAttribute<AgentRpcAttribute>();
+        if (rpcAttr == null)
+        {
+            throw new InvalidOperationException(
+                $"Method '{method.Name}' is not marked with [AgentRpc]");
+        }
+    }
+    
+    private object?[] DeserializeProtobufArgs(
+        RepeatedField<Any> protoArgs, 
+        ParameterInfo[] paramInfos)
+    {
+        var args = new object?[paramInfos.Length];
+        for (int i = 0; i < paramInfos.Length; i++)
+        {
+            if (i < protoArgs.Count)
+            {
+                args[i] = UnpackArg(protoArgs[i], paramInfos[i].ParameterType);
+            }
+            else if (paramInfos[i].HasDefaultValue)
+            {
+                args[i] = paramInfos[i].DefaultValue;
+            }
+        }
+        return args;
+    }
+    
+    private object? UnpackArg(Any any, Type targetType)
+    {
+        // 处理基础类型
+        if (targetType == typeof(int))
+            return any.Unpack<Int32Value>().Value;
+        if (targetType == typeof(long))
+            return any.Unpack<Int64Value>().Value;
+        if (targetType == typeof(string))
+            return any.Unpack<StringValue>().Value;
+        if (targetType == typeof(bool))
+            return any.Unpack<BoolValue>().Value;
+        if (targetType == typeof(double))
+            return any.Unpack<DoubleValue>().Value;
+        
+        // 处理 Protobuf 消息类型
+        if (typeof(IMessage).IsAssignableFrom(targetType))
+        {
+            var parser = targetType.GetProperty("Parser", 
+                BindingFlags.Public | BindingFlags.Static)!;
+            var parserInstance = parser.GetValue(null) as MessageParser;
+            return any.Unpack(parserInstance!.GetType());
+        }
+        
+        throw new NotSupportedException($"Type {targetType} not supported for RPC");
+    }
+    
+    private Any PackResult(object result)
+    {
+        return result switch
+        {
+            int i => Any.Pack(new Int32Value { Value = i }),
+            long l => Any.Pack(new Int64Value { Value = l }),
+            string s => Any.Pack(new StringValue { Value = s }),
+            bool b => Any.Pack(new BoolValue { Value = b }),
+            double d => Any.Pack(new DoubleValue { Value = d }),
+            IMessage msg => Any.Pack(msg),
+            _ => throw new NotSupportedException($"Type {result.GetType()} not supported")
+        };
+    }
+}
+```
+
+---
+
+### Step 4: Source Generator 生成 Proxy
+
+```csharp
+// ===== Source Generator =====
+[Generator]
+public class AgentRpcProxyGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // 查找所有 [AgentRpc] 标记的接口
+        var interfaces = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: (node, _) => node is InterfaceDeclarationSyntax,
+                transform: (ctx, _) => GetAgentRpcInterface(ctx))
+            .Where(i => i != null);
+        
+        context.RegisterSourceOutput(interfaces, GenerateProxy!);
+    }
+    
+    private void GenerateProxy(
+        SourceProductionContext context, 
+        InterfaceDeclarationSyntax iface)
+    {
+        var interfaceName = iface.Identifier.Text;
+        var proxyName = $"{interfaceName}Proxy";
+        var ns = GetNamespace(iface);
+        
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using Aevatar.Agents.Abstractions;");
+        sb.AppendLine("using Aevatar.Agents.Rpc;");
+        sb.AppendLine("using Google.Protobuf;");
+        sb.AppendLine("using Google.Protobuf.WellKnownTypes;");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {ns};");
+        sb.AppendLine();
+        sb.AppendLine($"/// <summary>");
+        sb.AppendLine($"/// Auto-generated RPC proxy for {interfaceName}");
+        sb.AppendLine($"/// </summary>");
+        sb.AppendLine($"public sealed class {proxyName} : {interfaceName}");
+        sb.AppendLine("{");
+        sb.AppendLine("    private readonly IGAgentActor _actor;");
+        sb.AppendLine();
+        sb.AppendLine($"    public {proxyName}(IGAgentActor actor)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        _actor = actor ?? throw new ArgumentNullException(nameof(actor));");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    public Guid Id => _actor.Id;");
+        sb.AppendLine();
+        
+        // 生成每个方法的代理实现
+        foreach (var method in iface.Members.OfType<MethodDeclarationSyntax>())
+        {
+            sb.AppendLine(GenerateMethodProxy(method));
+        }
+        
+        // 生成 IGAgent 必需的方法
+        sb.AppendLine("    public Task<string> GetDescriptionAsync()");
+        sb.AppendLine("        => _actor.GetDescriptionAsync();");
+        sb.AppendLine();
+        sb.AppendLine("    public Task ActivateAsync(CancellationToken ct = default)");
+        sb.AppendLine("        => _actor.ActivateAsync(ct);");
+        sb.AppendLine();
+        sb.AppendLine("    public Task DeactivateAsync(CancellationToken ct = default)");
+        sb.AppendLine("        => _actor.DeactivateAsync(ct);");
+        
+        sb.AppendLine("}");
+        
+        context.AddSource($"{proxyName}.g.cs", sb.ToString());
+    }
+    
+    private string GenerateMethodProxy(MethodDeclarationSyntax method)
+    {
+        var methodName = method.Identifier.Text;
+        var returnType = method.ReturnType.ToString();
+        var parameters = method.ParameterList.Parameters;
+        
+        var sb = new StringBuilder();
+        
+        // 方法签名
+        var paramList = string.Join(", ", 
+            parameters.Select(p => $"{p.Type} {p.Identifier}"));
+        sb.AppendLine($"    public async {returnType} {methodName}({paramList})");
+        sb.AppendLine("    {");
+        
+        // 构建 RpcRequest
+        sb.AppendLine("        var request = new RpcRequest");
+        sb.AppendLine("        {");
+        sb.AppendLine($"            MethodName = \"{methodName}\",");
+        sb.AppendLine($"            CorrelationId = Guid.NewGuid().ToString()");
+        sb.AppendLine("        };");
+        sb.AppendLine();
+        
+        // 添加参数
+        foreach (var param in parameters)
+        {
+            var paramName = param.Identifier.Text;
+            var paramType = param.Type!.ToString();
+            sb.AppendLine($"        request.Args.Add({GeneratePackCode(paramName, paramType)});");
+        }
+        sb.AppendLine();
+        
+        // 调用 RPC
+        sb.AppendLine("        var responseBytes = await _actor.InvokeRpcAsync(request.ToByteArray());");
+        sb.AppendLine("        var response = RpcResponse.Parser.ParseFrom(responseBytes);");
+        sb.AppendLine();
+        sb.AppendLine("        if (!response.Success)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            throw new RpcException(response.Error?.Message ?? \"RPC failed\");");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        
+        // 处理返回值
+        if (returnType == "Task")
+        {
+            // void 返回
+        }
+        else if (returnType.StartsWith("Task<"))
+        {
+            var innerType = ExtractGenericType(returnType);
+            sb.AppendLine($"        return {GenerateUnpackCode("response.Result", innerType)};");
+        }
+        
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        
+        return sb.ToString();
+    }
+    
+    private string GeneratePackCode(string varName, string typeName)
+    {
+        return typeName switch
+        {
+            "int" => $"Any.Pack(new Int32Value {{ Value = {varName} }})",
+            "long" => $"Any.Pack(new Int64Value {{ Value = {varName} }})",
+            "string" => $"Any.Pack(new StringValue {{ Value = {varName} }})",
+            "bool" => $"Any.Pack(new BoolValue {{ Value = {varName} }})",
+            "double" => $"Any.Pack(new DoubleValue {{ Value = {varName} }})",
+            _ when typeName.EndsWith("?") => 
+                $"{varName} != null ? Any.Pack({varName}) : Any.Pack(new Empty())",
+            _ => $"Any.Pack({varName})"  // Assume IMessage
+        };
+    }
+    
+    private string GenerateUnpackCode(string varName, string typeName)
+    {
+        return typeName switch
+        {
+            "int" => $"{varName}.Unpack<Int32Value>().Value",
+            "long" => $"{varName}.Unpack<Int64Value>().Value",
+            "string" => $"{varName}.Unpack<StringValue>().Value",
+            "string?" => $"{varName}?.Unpack<StringValue>()?.Value",
+            "bool" => $"{varName}.Unpack<BoolValue>().Value",
+            "double" => $"{varName}.Unpack<DoubleValue>().Value",
+            _ => $"{varName}.Unpack<{typeName}>()"
+        };
+    }
+}
+```
+
+---
+
+### Step 5: 使用示例
+
+```csharp
+// ===== 1. 定义 Agent 接口 =====
+[AgentRpc]
+public interface IPaymentIndexGAgent : IGAgent
+{
+    [AgentRpc]
+    Task<string?> GetPlatformCustomerIdAsync(int platform);
+    
+    [AgentRpc]
+    Task SetPlatformCustomerIdAsync(int platform, string customerId);
+    
+    [AgentRpc]
+    Task<PaymentIndexStateProto> GetStateAsync();
+}
+
+// ===== 2. 实现 Agent =====
+public class PaymentIndexGAgent : GAgentBase<PaymentIndexStateProto>, IPaymentIndexGAgent
+{
+    [AgentRpc]
+    public Task<string?> GetPlatformCustomerIdAsync(int platform)
+    {
+        State.PlatformCustomers.TryGetValue(platform, out var customerId);
+        return Task.FromResult(customerId);
+    }
+    
+    [AgentRpc]
+    public async Task SetPlatformCustomerIdAsync(int platform, string customerId)
+    {
+        RaiseEvent(new CustomerIdUpdatedEvent 
+        { 
+            Platform = platform, 
+            CustomerId = customerId 
+        });
+        await ConfirmEventsAsync();
+    }
+    
+    [AgentRpc]
+    public Task<PaymentIndexStateProto> GetStateAsync()
+    {
+        return Task.FromResult(State);
+    }
+}
+
+// ===== 3. 使用 (自动生成的 Proxy) =====
+public class PaymentService : IPaymentService
+{
+    private readonly IGAgentActorFactory _actorFactory;
+    
+    public async Task<string?> GetCustomerIdAsync(Guid userId, int platform)
+    {
+        // 创建 Actor
+        var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+        
+        // 使用生成的 Proxy（完全类型安全！）
+        var proxy = new IPaymentIndexGAgentProxy(actor);
+        
+        // 直接调用方法 - Protobuf 序列化，高性能！
+        return await proxy.GetPlatformCustomerIdAsync(platform);
+    }
+}
+```
+
+---
+
+### 扩展方法（便捷使用）
+
+```csharp
+public static class AgentActorExtensions
+{
+    /// <summary>
+    /// 获取类型安全的 Agent RPC 代理
+    /// </summary>
+    public static TAgent AsProxy<TAgent>(this IGAgentActor actor) 
+        where TAgent : class, IGAgent
+    {
+        // 查找 Source Generator 生成的 Proxy 类
+        var proxyTypeName = $"{typeof(TAgent).FullName}Proxy";
+        var proxyType = typeof(TAgent).Assembly.GetType(proxyTypeName);
+        
+        if (proxyType == null)
+        {
+            throw new InvalidOperationException(
+                $"Proxy type '{proxyTypeName}' not found. " +
+                $"Ensure interface is marked with [AgentRpc].");
+        }
+        
+        return (TAgent)Activator.CreateInstance(proxyType, actor)!;
+    }
+}
+
+// 使用
+var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+var proxy = actor.AsProxy<IPaymentIndexGAgent>();  // 更简洁！
+var customerId = await proxy.GetPlatformCustomerIdAsync(1);
+```
+
+---
+
+## 支持的类型
+
+### 基础类型 (自动映射)
+
+| C# 类型 | Protobuf Wrapper |
+|---------|------------------|
+| `int` | `Int32Value` |
+| `long` | `Int64Value` |
+| `string` | `StringValue` |
+| `bool` | `BoolValue` |
+| `double` | `DoubleValue` |
+| `float` | `FloatValue` |
+| `byte[]` | `BytesValue` |
+
+### 复杂类型
+
+```csharp
+// 自定义 Protobuf 消息直接支持
+[AgentRpc]
+Task<PaymentRecordStateProto> GetRecordAsync(string paymentId);
+
+// 集合类型需要包装为 Protobuf 消息
+message GetRecordsResponse {
+    repeated PaymentRecordStateProto records = 1;
+}
+
+[AgentRpc]
+Task<GetRecordsResponse> GetRecordsAsync(int limit);
+```
+
+---
+
+## 实现路线图
+
+```
+Phase 1: 基础设施 (2 天)
+├── 定义 agent_rpc.proto (RpcRequest/RpcResponse)
+├── 扩展 IGAgentGrain.InvokeRpcAsync(byte[])
+├── 实现 OrleansGAgentGrain Protobuf 反序列化调用
+├── 实现 OrleansGAgentActor.InvokeRpcAsync(byte[])
+└── 添加 [AgentRpc] 特性
+
+Phase 2: Source Generator (3 天)
+├── 创建 Aevatar.Agents.SourceGen 项目 (netstandard2.0)
+├── 实现 AgentRpcProxyGenerator (IIncrementalGenerator)
+├── 生成 Proxy 类（Protobuf 序列化）
+├── 生成扩展方法 AsProxy<T>()
+└── 单元测试
+
+Phase 3: 优化 (1 天)
+├── 方法签名缓存 (已内置)
+├── 表达式树替代反射（可选）
+└── 批量调用支持（可选）
+```
+
+---
+
+## 项目结构
+
+```
+src/
+├── Aevatar.Agents.Abstractions/
+│   ├── Attributes/
+│   │   └── AgentRpcAttribute.cs      # [AgentRpc] 特性
+│   └── Protos/
+│       └── agent_rpc.proto           # RPC 消息定义
+│
+├── Aevatar.Agents.SourceGen/         # Source Generator 项目
+│   ├── AgentRpcProxyGenerator.cs     # 代理生成器
+│   └── Aevatar.Agents.SourceGen.csproj  # netstandard2.0
+│
+└── Aevatar.Agents.Runtime.Orleans/
+    ├── IGAgentGrain.cs               # 添加 InvokeRpcAsync
+    └── OrleansGAgentGrain.cs         # 实现 Protobuf RPC
+```
+
+---
+
+## 最终对比
+
+| 方案 | 易用性 | 类型安全 | 性能 | 扩展性 | 推荐度 |
+|------|--------|----------|------|--------|--------|
+| 方案一：JSON RPC | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | 快速原型 |
+| 方案二：DispatchProxy | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | 不推荐 |
+| 方案三：手写 Protobuf | ⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ | 繁琐 |
+| **Source Gen + Protobuf** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | **🏆 最优** |
+
+---
+
+## 性能对比
+
+| 序列化方式 | 1000 次调用 | 内存分配 | 包大小 |
+|------------|-------------|----------|--------|
+| JSON | ~150ms | ~2MB | 较大 |
+| **Protobuf** | **~25ms** | **~300KB** | **紧凑** |
+| MessagePack | ~30ms | ~350KB | 紧凑 |
+
+---
+
+## 总结
+
+**Source Generator + Protobuf** 是最优方案：
+
+1. ✅ **编译时类型安全** - IDE 完整支持
+2. ✅ **零运行时反射** - 代理代码编译时生成
+3. ✅ **高性能** - Protobuf 二进制序列化
+4. ✅ **易于使用** - `actor.AsProxy<IMyAgent>()`
+5. ✅ **版本兼容** - Protobuf 前后向兼容
+6. ✅ **可维护** - 自动生成，无需手写
+
+```csharp
+// 最终使用体验
+var actor = await _actorFactory.CreateGAgentActorAsync<PaymentIndexGAgent>(userId);
+var proxy = actor.AsProxy<IPaymentIndexGAgent>();
+
+// 完全类型安全 + Protobuf 高性能！
+var customerId = await proxy.GetPlatformCustomerIdAsync(PaymentPlatform.Stripe);
+var state = await proxy.GetStateAsync();
+```
+

--- a/examples/Demo.Agents/IBankAccountAgent.cs
+++ b/examples/Demo.Agents/IBankAccountAgent.cs
@@ -1,0 +1,18 @@
+using Aevatar.Agents.Abstractions;
+
+namespace Demo.Agents;
+
+/// <summary>
+/// BankAccountAgent RPC interface
+/// </summary>
+public interface IBankAccountAgent : IGAgent
+{
+    Task CreateAccountAsync(string accountHolder, double initialBalance = 0);
+    Task DepositAsync(double amount, string description = "");
+    Task WithdrawAsync(double amount, string description = "");
+    Task<double> GetBalanceAsync();
+    Task<string> GetAccountHolderAsync();
+    Task<int> GetTransactionCountAsync();
+    Task<long> GetCurrentVersionAsync();
+}
+

--- a/examples/EventSourcingDemo/BankAccountAgent.cs
+++ b/examples/EventSourcingDemo/BankAccountAgent.cs
@@ -11,7 +11,7 @@ namespace EventSourcingDemo;
 /// 支持 EventSourcing 的银行账户 Agent
 /// 使用新的批量提交和纯函数式状态转换模式
 /// </summary>
-public class BankAccountAgent : GAgentBase<BankAccountState>
+public class BankAccountAgent : GAgentBase<BankAccountState>, IBankAccountAgent
 {
     public override Task<string> GetDescriptionAsync()
     {
@@ -196,5 +196,53 @@ public class BankAccountAgent : GAgentBase<BankAccountState>
 
         Logger?.LogInformation("   New state: Balance=${Balance}, Transactions={Count}", state.Balance,
             state.TransactionCount);
+    }
+
+    // ========== RPC Query Methods (Interface Implementation) ==========
+
+    /// <summary>
+    /// Get current account balance
+    /// </summary>
+    public Task<double> GetBalanceAsync()
+    {
+        return Task.FromResult(State.Balance);
+    }
+
+    /// <summary>
+    /// Get account holder name
+    /// </summary>
+    public Task<string> GetAccountHolderAsync()
+    {
+        return Task.FromResult(State.AccountHolder);
+    }
+
+    /// <summary>
+    /// Get transaction count
+    /// </summary>
+    public Task<int> GetTransactionCountAsync()
+    {
+        return Task.FromResult(State.TransactionCount);
+    }
+
+    /// <summary>
+    /// Get current version
+    /// </summary>
+    public Task<long> GetCurrentVersionAsync()
+    {
+        return Task.FromResult(GetCurrentVersion());
+    }
+
+    /// <summary>
+    /// Get account summary
+    /// </summary>
+    public Task<Events.AccountSummary> GetAccountSummaryAsync()
+    {
+        return Task.FromResult(new Events.AccountSummary
+        {
+            AccountHolder = State.AccountHolder,
+            Balance = State.Balance,
+            TransactionCount = State.TransactionCount,
+            Version = GetCurrentVersion()
+        });
     }
 }

--- a/examples/EventSourcingDemo/EventSourcingDemo.csproj
+++ b/examples/EventSourcingDemo/EventSourcingDemo.csproj
@@ -12,12 +12,16 @@
         <ProjectReference Include="..\..\src\Aevatar.Agents.Core\Aevatar.Agents.Core.csproj" />
         <ProjectReference Include="..\..\src\Aevatar.Agents.Runtime.Local\Aevatar.Agents.Runtime.Local.csproj" />
         <ProjectReference Include="..\..\src\Aevatar.Agents.Runtime.ProtoActor\Aevatar.Agents.Runtime.ProtoActor.csproj" />
+        <ProjectReference Include="..\..\src\Aevatar.Agents.Runtime.Orleans\Aevatar.Agents.Runtime.Orleans.csproj" />
         <ProjectReference Include="..\Demo.Agents\Demo.Agents.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Orleans.Server" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" />
         <PackageReference Include="Google.Protobuf" />
         <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>

--- a/examples/EventSourcingDemo/IBankAccountAgent.cs
+++ b/examples/EventSourcingDemo/IBankAccountAgent.cs
@@ -1,0 +1,51 @@
+using Aevatar.Agents.Abstractions;
+
+namespace EventSourcingDemo;
+
+/// <summary>
+/// Bank Account Agent interface for RPC calls
+/// Methods defined in this interface can be called via RPC
+/// </summary>
+public interface IBankAccountAgent : IGAgent
+{
+    /// <summary>
+    /// Create a new account
+    /// </summary>
+    Task CreateAccountAsync(string accountHolder, decimal initialBalance = 0);
+
+    /// <summary>
+    /// Deposit money into the account
+    /// </summary>
+    Task DepositAsync(decimal amount, string description = "");
+
+    /// <summary>
+    /// Withdraw money from the account
+    /// </summary>
+    Task WithdrawAsync(decimal amount, string description = "");
+
+    /// <summary>
+    /// Get current account balance
+    /// </summary>
+    Task<double> GetBalanceAsync();
+
+    /// <summary>
+    /// Get account holder name
+    /// </summary>
+    Task<string> GetAccountHolderAsync();
+
+    /// <summary>
+    /// Get transaction count
+    /// </summary>
+    Task<int> GetTransactionCountAsync();
+
+    /// <summary>
+    /// Get current version
+    /// </summary>
+    Task<long> GetCurrentVersionAsync();
+
+    /// <summary>
+    /// Get account summary
+    /// </summary>
+    Task<Events.AccountSummary> GetAccountSummaryAsync();
+}
+

--- a/examples/EventSourcingDemo/MultiRuntimeEventSourcingDemo.cs
+++ b/examples/EventSourcingDemo/MultiRuntimeEventSourcingDemo.cs
@@ -1,10 +1,15 @@
 using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.Abstractions.EventSourcing;
+using Aevatar.Agents.Abstractions.Extensions;
 using Aevatar.Agents.AI.Core;
 using Aevatar.Agents.Core.EventSourcing;
+using Aevatar.Agents.Core.Extensions;
 using Aevatar.Agents.Runtime.Local;
+using Aevatar.Agents.Runtime.Orleans;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
 
 namespace EventSourcingDemo;
 
@@ -32,8 +37,8 @@ public static class MultiRuntimeEventSourcingDemo
         // 1. Local 运行时演示
         await DemoLocalRuntime(sharedEventStore, serviceProvider);
         
-        // 2. Orleans 运行时说明
-        ShowOrleansInstructions();
+        // 2. Orleans 运行时演示
+        await DemoOrleansRuntime();
         
         Console.WriteLine("\n✅ Multi-Runtime EventSourcing Demo 完成！");
         Console.WriteLine("🌟 所有运行时都使用统一的 EventSourcing API！");
@@ -80,6 +85,48 @@ public static class MultiRuntimeEventSourcingDemo
         Console.WriteLine($"\n  💵 Balance: ${agent.GetState().Balance:F2}");
         Console.WriteLine($"  📈 Version: v{agent.GetCurrentVersion()}");
         Console.WriteLine($"  🔢 Transactions: {agent.GetState().TransactionCount}");
+        
+        // ✅ 场景1.5：RPC 接口调用测试
+        Console.WriteLine("\n⚡ 场景1.5：RPC 接口调用测试");
+        Console.WriteLine("───────────────────────────────────────────────");
+        
+        try
+        {
+            // Test RPC calls via interface (using extension method)
+            var balance = await actor.InvokeRpcAsync<double>("GetBalanceAsync");
+            var holder = await actor.InvokeRpcAsync<string>("GetAccountHolderAsync");
+            var txCount = await actor.InvokeRpcAsync<int>("GetTransactionCountAsync");
+            var version = await actor.InvokeRpcAsync<long>("GetCurrentVersionAsync");
+            var summary = await actor.InvokeRpcAsync<Events.AccountSummary>("GetAccountSummaryAsync");
+            
+            Console.WriteLine($"  ✅ RPC GetBalanceAsync: ${balance:F2}");
+            Console.WriteLine($"  ✅ RPC GetAccountHolderAsync: {holder}");
+            Console.WriteLine($"  ✅ RPC GetTransactionCountAsync: {txCount}");
+            Console.WriteLine($"  ✅ RPC GetCurrentVersionAsync: v{version}");
+            Console.WriteLine($"  ✅ RPC GetAccountSummaryAsync:");
+            Console.WriteLine($"     - Holder: {summary.AccountHolder}");
+            Console.WriteLine($"     - Balance: ${summary.Balance:F2}");
+            Console.WriteLine($"     - Transactions: {summary.TransactionCount}");
+            Console.WriteLine($"     - Version: v{summary.Version}");
+            
+            // Verify RPC results match direct access
+            if (Math.Abs(balance - agent.GetState().Balance) < 0.01 &&
+                holder == agent.GetState().AccountHolder &&
+                txCount == agent.GetState().TransactionCount &&
+                version == agent.GetCurrentVersion())
+            {
+                Console.WriteLine($"\n  🎉 RPC 调用验证成功！所有接口调用结果正确！");
+            }
+            else
+            {
+                Console.WriteLine($"\n  ⚠️ RPC 调用结果与直接访问不匹配");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  ❌ RPC 调用失败: {ex.Message}");
+            Console.WriteLine($"     {ex.GetType().Name}: {ex.StackTrace}");
+        }
         
         // ✅ 场景2：批量交易演示
         Console.WriteLine("\n⚡ 场景2：批量交易（展示批量提交优势）");
@@ -128,6 +175,31 @@ public static class MultiRuntimeEventSourcingDemo
             {
                 Console.WriteLine($"\n  🎉 Local Runtime EventSourcing 验证成功!");
             }
+            
+            // ✅ 场景3.5：恢复后 RPC 调用测试
+            Console.WriteLine("\n⚡ 场景3.5：恢复后 RPC 调用测试");
+            Console.WriteLine("───────────────────────────────────────────────");
+            
+            try
+            {
+                var recoveredBalance = await newActor.InvokeRpcAsync<double>("GetBalanceAsync");
+                var recoveredSummary = await newActor.InvokeRpcAsync<Events.AccountSummary>("GetAccountSummaryAsync");
+                
+                Console.WriteLine($"  ✅ 恢复后 RPC GetBalanceAsync: ${recoveredBalance:F2}");
+                Console.WriteLine($"  ✅ 恢复后 RPC GetAccountSummaryAsync:");
+                Console.WriteLine($"     - Balance: ${recoveredSummary.Balance:F2}");
+                Console.WriteLine($"     - Version: v{recoveredSummary.Version}");
+                
+                if (Math.Abs(recoveredBalance - recoveredAgent.GetState().Balance) < 0.01 &&
+                    recoveredSummary.Version == recoveredAgent.GetCurrentVersion())
+                {
+                    Console.WriteLine($"\n  🎉 恢复后 RPC 调用验证成功！");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  ❌ 恢复后 RPC 调用失败: {ex.Message}");
+            }
         }
         
         // ✅ 场景4：展示事件元数据
@@ -151,52 +223,123 @@ public static class MultiRuntimeEventSourcingDemo
     }
     
     /// <summary>
-    /// Orleans 运行时说明
+    /// Orleans 运行时演示
     /// </summary>
-    private static void ShowOrleansInstructions()
+    private static async Task DemoOrleansRuntime()
     {
-        Console.WriteLine("\n\n📍 Orleans Runtime EventSourcing");
+        Console.WriteLine("\n\n📍 Orleans Runtime EventSourcing + RPC");
         Console.WriteLine("════════════════════════════════════════════");
-        Console.WriteLine("✅ Orleans 现在使用统一的 IEventStore 接口！\n");
         
-        Console.WriteLine("🔧 配置方式 (ServiceProvider):");
-        Console.WriteLine("───────────────────────────────────────────────");
-        Console.WriteLine("```csharp");
-        Console.WriteLine("// 在 ServiceProvider 中注册 EventStore");
-        Console.WriteLine("services.AddSingleton<IEventStore, OrleansEventStore>();");
-        Console.WriteLine("");
-        Console.WriteLine("// 注册 AIGAgentFactory");
-        Console.WriteLine("services.AddSingleton<IGAgentFactory, AIGAgentFactory>();");
-        Console.WriteLine("```\n");
+        // 启动内嵌 Orleans Silo
+        Console.WriteLine("🚀 启动 Orleans Silo...");
         
-        Console.WriteLine("💡 使用方式 (完全透明):");
-        Console.WriteLine("───────────────────────────────────────────────");
-        Console.WriteLine("```csharp");
-        Console.WriteLine("// AIGAgentFactory 会自动检测并注入 EventStore");
-        Console.WriteLine("var factory = serviceProvider.GetRequiredService<IGAgentFactory>();");
-        Console.WriteLine("var actor = await factory.CreateGAgent<BankAccountAgent>(agentId);");
-        Console.WriteLine("");
-        Console.WriteLine("// EventStore 已自动注入到 Agent 中");
-        Console.WriteLine("// OnActivateAsync 会自动重放事件");
-        Console.WriteLine("```\n");
+        var host = Host.CreateDefaultBuilder()
+            .UseOrleans((context, siloBuilder) =>
+            {
+                siloBuilder.UseLocalhostClustering();
+                siloBuilder.AddMemoryGrainStorage("Default");
+                siloBuilder.AddMemoryStreams("Default");
+                siloBuilder.Configure<ClusterOptions>(options =>
+                {
+                    options.ClusterId = "eventsourcing-demo";
+                    options.ServiceId = "bank-demo";
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+                // EventStore - required for state updates
+                services.AddSingleton<InMemoryEventStore>();
+                services.AddSingleton<IEventStore>(p => p.GetRequiredService<InMemoryEventStore>());
+                services.AddSingleton<IGAgentFactory, AIGAgentFactory>();
+                services.AddGAgentActorFactoryProvider();
+            })
+            .Build();
         
-        Console.WriteLine("🌟 统一的 EventSourcing 特性:");
-        Console.WriteLine("  ✓ 批量事件提交 (RaiseEvent + ConfirmEventsAsync)");
-        Console.WriteLine("  ✓ 纯函数式状态转换 (TransitionState)");
-        Console.WriteLine("  ✓ 自动事件重放 (OnActivateAsync)");
-        Console.WriteLine("  ✓ 快照支持 (Snapshot Strategy)");
-        Console.WriteLine("  ✓ 乐观并发控制 (Optimistic Concurrency)");
-        Console.WriteLine("  ✓ 元数据支持 (Metadata)");
-        Console.WriteLine("  ✓ GrainStorage 持久化 (支持多种存储提供者)");
+        await host.StartAsync();
+        Console.WriteLine("✅ Orleans Silo 已启动\n");
         
-        Console.WriteLine("\n📝 存储提供者支持:");
-        Console.WriteLine("  • MemoryGrainStorage (开发/测试)");
-        Console.WriteLine("  • AzureTableGrainStorage (生产)");
-        Console.WriteLine("  • AdoNetGrainStorage (SQL数据库)");
-        Console.WriteLine("  • 自定义存储提供者");
-        
-        Console.WriteLine("\n💡 提示: Orleans 需要运行完整的 Silo 服务器");
-        Console.WriteLine("        详见: examples/Demo.AppHost/Program.cs");
+        try
+        {
+            // 获取工厂
+            var clusterClient = host.Services.GetRequiredService<IClusterClient>();
+            var logger = host.Services.GetRequiredService<ILogger<OrleansGAgentActorFactory>>();
+            var factory = new OrleansGAgentActorFactory(host.Services, clusterClient, logger);
+            
+            var agentId = Guid.NewGuid();
+            Console.WriteLine($"Agent ID: {agentId:N}");
+            
+            // 创建 Orleans Actor
+            Console.WriteLine("\n⚡ 场景5：Orleans Runtime RPC 调用");
+            Console.WriteLine("───────────────────────────────────────────────");
+            
+            var actor = await factory.CreateGAgentActorAsync<BankAccountAgent>(agentId);
+            Console.WriteLine("  ✓ Orleans Actor 创建成功");
+            
+            // 通过 RPC 创建账户 (decimal 转成 double 传输)
+            Console.Write("  RPC CreateAccountAsync... ");
+            await actor.InvokeRpcAsync("CreateAccountAsync", "Orleans User", 2000m);
+            Console.WriteLine("✅");
+            
+            // 通过 RPC 存款
+            Console.Write("  RPC DepositAsync(800)... ");
+            await actor.InvokeRpcAsync("DepositAsync", 800m, "Orleans Deposit");
+            Console.WriteLine("✅");
+            
+            // 通过 RPC 取款
+            Console.Write("  RPC WithdrawAsync(300)... ");
+            await actor.InvokeRpcAsync("WithdrawAsync", 300m, "Orleans Withdraw");
+            Console.WriteLine("✅");
+            
+            // 通过 RPC 获取状态
+            Console.Write("  RPC GetBalanceAsync... ");
+            var balance = await actor.InvokeRpcAsync<double>("GetBalanceAsync");
+            Console.WriteLine($"✅ 返回: ${balance:F2}");
+            
+            Console.Write("  RPC GetAccountHolderAsync... ");
+            var holder = await actor.InvokeRpcAsync<string>("GetAccountHolderAsync");
+            Console.WriteLine($"✅ 返回: {holder}");
+            
+            Console.Write("  RPC GetTransactionCountAsync... ");
+            var txCount = await actor.InvokeRpcAsync<int>("GetTransactionCountAsync");
+            Console.WriteLine($"✅ 返回: {txCount}");
+            
+            Console.Write("  RPC GetAccountSummaryAsync... ");
+            var summary = await actor.InvokeRpcAsync<Events.AccountSummary>("GetAccountSummaryAsync");
+            Console.WriteLine("✅");
+            Console.WriteLine($"     - Holder: {summary.AccountHolder}");
+            Console.WriteLine($"     - Balance: ${summary.Balance:F2}");
+            Console.WriteLine($"     - Transactions: {summary.TransactionCount}");
+            Console.WriteLine($"     - Version: v{summary.Version}");
+            
+            // 验证 (TransactionCount = 2: Deposit + Withdraw, CreateAccount sets it to 0)
+            var expectedBalance = 2000.0 + 800.0 - 300.0; // 2500
+            if (Math.Abs(balance - expectedBalance) < 0.01 && 
+                holder == "Orleans User" && 
+                txCount == 2)
+            {
+                Console.WriteLine($"\n  🎉 Orleans Runtime RPC 验证成功！");
+                Console.WriteLine($"     预期余额: ${expectedBalance:F2}, 实际: ${balance:F2}");
+                Console.WriteLine($"     交易数: {txCount}");
+            }
+            else
+            {
+                Console.WriteLine($"\n  ❌ Orleans Runtime RPC 验证失败");
+                Console.WriteLine($"     预期余额: ${expectedBalance:F2}, 实际: ${balance:F2}");
+                Console.WriteLine($"     预期交易数: 2, 实际: {txCount}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\n  ❌ Orleans RPC 调用失败: {ex.Message}");
+            Console.WriteLine($"     {ex.StackTrace}");
+        }
+        finally
+        {
+            Console.WriteLine("\n🛑 停止 Orleans Silo...");
+            await host.StopAsync();
+            Console.WriteLine("✅ Orleans Silo 已停止");
+        }
     }
     
     /// <summary>

--- a/examples/EventSourcingDemo/bank_events.proto
+++ b/examples/EventSourcingDemo/bank_events.proto
@@ -21,3 +21,11 @@ message AccountCreated {
     string account_holder = 1;
     double initial_balance = 2;
 }
+
+// 账户摘要（用于 RPC 返回）
+message AccountSummary {
+    string account_holder = 1;
+    double balance = 2;
+    int32 transaction_count = 3;
+    int64 version = 4;
+}

--- a/src/Aevatar.Agents.Abstractions/Extensions/RpcExtensions.cs
+++ b/src/Aevatar.Agents.Abstractions/Extensions/RpcExtensions.cs
@@ -1,0 +1,62 @@
+using Aevatar.Agents.Abstractions.Rpc;
+using Aevatar.Agents.Rpc;
+using Google.Protobuf;
+
+namespace Aevatar.Agents.Abstractions.Extensions;
+
+/// <summary>
+/// Extension methods for RPC calls on IGAgentActor
+/// </summary>
+public static class RpcExtensions
+{
+    /// <summary>
+    /// Invoke RPC method with typed result
+    /// </summary>
+    public static async Task<TResult> InvokeRpcAsync<TResult>(
+        this IGAgentActor actor,
+        string methodName,
+        params object?[] args)
+    {
+        var response = await InvokeRpcCoreAsync(actor, methodName, args);
+        return ProtobufPacker.Unpack<TResult>(response.Result);
+    }
+
+    /// <summary>
+    /// Invoke RPC method without return value
+    /// </summary>
+    public static async Task InvokeRpcAsync(
+        this IGAgentActor actor,
+        string methodName,
+        params object?[] args)
+    {
+        await InvokeRpcCoreAsync(actor, methodName, args);
+    }
+
+    private static async Task<RpcResponse> InvokeRpcCoreAsync(
+        IGAgentActor actor,
+        string methodName,
+        object?[] args)
+    {
+        var request = new RpcRequest
+        {
+            MethodName = methodName,
+            CorrelationId = Guid.NewGuid().ToString()
+        };
+
+        foreach (var arg in args)
+        {
+            request.Args.Add(ProtobufPacker.Pack(arg));
+        }
+
+        var responseBytes = await actor.InvokeRpcAsync(request.ToByteArray());
+        var response = RpcResponse.Parser.ParseFrom(responseBytes);
+
+        if (!response.Success)
+        {
+            throw new InvalidOperationException(
+                $"RPC call failed: {response.Error?.Message ?? "Unknown error"}");
+        }
+
+        return response;
+    }
+}

--- a/src/Aevatar.Agents.Abstractions/IGAgentActor.cs
+++ b/src/Aevatar.Agents.Abstractions/IGAgentActor.cs
@@ -58,4 +58,13 @@ public interface IGAgentActor : IEventPublisher
     /// Deactivate the Actor.
     /// </summary>
     Task DeactivateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Invoke RPC method on Agent via Protobuf.
+    /// For Local runtime, this may directly call the method.
+    /// For Orleans runtime, this calls the Grain RPC method.
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    Task<byte[]> InvokeRpcAsync(byte[] requestBytes);
 }

--- a/src/Aevatar.Agents.Abstractions/Rpc/ProtobufPacker.cs
+++ b/src/Aevatar.Agents.Abstractions/Rpc/ProtobufPacker.cs
@@ -1,0 +1,83 @@
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using System.Reflection;
+
+namespace Aevatar.Agents.Abstractions.Rpc;
+
+/// <summary>
+/// Shared Protobuf packing/unpacking utilities for RPC.
+/// Used by both client-side (RpcExtensions) and server-side (RpcInvoker).
+/// </summary>
+public static class ProtobufPacker
+{
+    // Cache the generic Unpack method to avoid repeated reflection
+    private static readonly MethodInfo? UnpackMethod = typeof(Any)
+        .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+        .FirstOrDefault(m => m.Name == "Unpack" && m.IsGenericMethod && m.GetParameters().Length == 0);
+
+    /// <summary>
+    /// Pack a value into Protobuf Any
+    /// </summary>
+    public static Any Pack(object? value)
+    {
+        // Handle null and void task results
+        if (value == null || value.GetType().FullName == "System.Threading.Tasks.VoidTaskResult")
+        {
+            return Any.Pack(new Empty());
+        }
+
+        return value switch
+        {
+            int i => Any.Pack(new Int32Value { Value = i }),
+            long l => Any.Pack(new Int64Value { Value = l }),
+            string s => Any.Pack(new StringValue { Value = s }),
+            bool b => Any.Pack(new BoolValue { Value = b }),
+            double d => Any.Pack(new DoubleValue { Value = d }),
+            float f => Any.Pack(new FloatValue { Value = f }),
+            decimal m => Any.Pack(new DoubleValue { Value = (double)m }), // decimal -> double
+            byte[] bytes => Any.Pack(new BytesValue { Value = ByteString.CopyFrom(bytes) }),
+            IMessage msg => Any.Pack(msg),
+            _ => throw new NotSupportedException($"Type {value.GetType()} is not supported for Protobuf packing")
+        };
+    }
+
+    /// <summary>
+    /// Unpack a Protobuf Any to target type
+    /// </summary>
+    public static object? Unpack(Any any, System.Type targetType)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(targetType);
+        var actualType = underlyingType ?? targetType;
+        var isNullable = underlyingType != null;
+
+        // Handle Protobuf message types first
+        if (typeof(IMessage).IsAssignableFrom(actualType) && UnpackMethod != null)
+        {
+            var genericUnpack = UnpackMethod.MakeGenericMethod(actualType);
+            return genericUnpack.Invoke(any, null);
+        }
+
+        // Handle primitive types
+        return actualType switch
+        {
+            var t when t == typeof(int) => isNullable ? (int?)any.Unpack<Int32Value>().Value : any.Unpack<Int32Value>().Value,
+            var t when t == typeof(long) => isNullable ? (long?)any.Unpack<Int64Value>().Value : any.Unpack<Int64Value>().Value,
+            var t when t == typeof(string) => isNullable && string.IsNullOrEmpty(any.Unpack<StringValue>().Value) ? null : any.Unpack<StringValue>().Value,
+            var t when t == typeof(bool) => isNullable ? (bool?)any.Unpack<BoolValue>().Value : any.Unpack<BoolValue>().Value,
+            var t when t == typeof(double) => isNullable ? (double?)any.Unpack<DoubleValue>().Value : any.Unpack<DoubleValue>().Value,
+            var t when t == typeof(float) => isNullable ? (float?)any.Unpack<FloatValue>().Value : any.Unpack<FloatValue>().Value,
+            var t when t == typeof(decimal) => isNullable ? (decimal?)Convert.ToDecimal(any.Unpack<DoubleValue>().Value) : Convert.ToDecimal(any.Unpack<DoubleValue>().Value),
+            var t when t == typeof(byte[]) => any.Unpack<BytesValue>().Value.ToByteArray(),
+            _ => throw new NotSupportedException($"Type {targetType} is not supported for Protobuf unpacking")
+        };
+    }
+
+    /// <summary>
+    /// Unpack a Protobuf Any to generic type T
+    /// </summary>
+    public static T Unpack<T>(Any any)
+    {
+        return (T)Unpack(any, typeof(T))!;
+    }
+}
+

--- a/src/Aevatar.Agents.Abstractions/agent_rpc.proto
+++ b/src/Aevatar.Agents.Abstractions/agent_rpc.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+package Aevatar.Agents.Rpc;
+
+option csharp_namespace = "Aevatar.Agents.Rpc";
+
+import "google/protobuf/any.proto";
+
+// RPC method invocation request
+message RpcRequest {
+    string method_name = 1;
+    repeated google.protobuf.Any args = 2;
+    map<string, string> metadata = 3;
+    string correlation_id = 4;
+}
+
+// RPC method invocation response
+message RpcResponse {
+    bool success = 1;
+    google.protobuf.Any result = 2;
+    RpcError error = 3;
+    string correlation_id = 4;
+}
+
+// RPC error information
+message RpcError {
+    string error_type = 1;
+    string message = 2;
+    string stack_trace = 3;
+}
+

--- a/src/Aevatar.Agents.Core/GAgentActorBase.cs
+++ b/src/Aevatar.Agents.Core/GAgentActorBase.cs
@@ -5,6 +5,7 @@ using Aevatar.Agents.Core.EventRouting;
 using Aevatar.Agents.Core.Helpers;
 using Aevatar.Agents.Core.Internal;
 using Aevatar.Agents.Core.Observability;
+using Aevatar.Agents.Core.Rpc;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -465,4 +466,17 @@ public abstract class GAgentActorBase : IGAgentActor, IActorHierarchyOperations
     /// Derived classes should override this method to perform specific deactivation logic
     /// </summary>
     protected virtual Task OnDeactivateAsync(CancellationToken ct) => Task.CompletedTask;
+
+    // ============ RPC Method Invocation ============
+
+    /// <summary>
+    /// Invoke RPC method on Agent via Protobuf.
+    /// Default implementation uses shared RpcInvoker.
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    public virtual Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
+    {
+        return RpcInvoker.InvokeAsync(Agent, requestBytes, Logger);
+    }
 }

--- a/src/Aevatar.Agents.Core/Rpc/RpcInvoker.cs
+++ b/src/Aevatar.Agents.Core/Rpc/RpcInvoker.cs
@@ -1,0 +1,109 @@
+using Aevatar.Agents.Abstractions;
+using Aevatar.Agents.Abstractions.Rpc;
+using Aevatar.Agents.Rpc;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Aevatar.Agents.Core.Rpc;
+
+/// <summary>
+/// Shared RPC invocation logic for all runtime implementations.
+/// Handles method discovery, argument deserialization, invocation, and result serialization.
+/// </summary>
+public static class RpcInvoker
+{
+    private static readonly ConcurrentDictionary<(System.Type, string), MethodInfo> MethodCache = new();
+
+    /// <summary>
+    /// Invoke RPC method on Agent
+    /// </summary>
+    public static async Task<byte[]> InvokeAsync(IGAgent agent, byte[] requestBytes, ILogger? logger = null)
+    {
+        var request = RpcRequest.Parser.ParseFrom(requestBytes);
+        var response = new RpcResponse
+        {
+            CorrelationId = request.CorrelationId,
+            Success = false
+        };
+
+        try
+        {
+            if (agent == null)
+                throw new InvalidOperationException("Agent not initialized");
+
+            var method = GetCachedMethod(agent.GetType(), request.MethodName);
+            var args = DeserializeArgs(request.Args, method.GetParameters());
+            var result = method.Invoke(agent, args);
+
+            // Handle async methods
+            if (result is Task task)
+            {
+                await task;
+                result = GetTaskResult(task);
+            }
+
+            if (result != null)
+            {
+                response.Result = ProtobufPacker.Pack(result);
+            }
+            response.Success = true;
+        }
+        catch (Exception ex)
+        {
+            var innerEx = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+            response.Error = new RpcError
+            {
+                ErrorType = innerEx.GetType().FullName ?? innerEx.GetType().Name,
+                Message = innerEx.Message,
+                StackTrace = innerEx.StackTrace ?? string.Empty
+            };
+            logger?.LogError(innerEx, "RPC method {Method} failed", request.MethodName);
+        }
+
+        return response.ToByteArray();
+    }
+
+    private static MethodInfo GetCachedMethod(System.Type agentType, string methodName)
+    {
+        return MethodCache.GetOrAdd((agentType, methodName), k =>
+        {
+            var method = k.Item1.GetMethod(k.Item2,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
+                ?? throw new InvalidOperationException($"Method '{k.Item2}' not found on type '{k.Item1.Name}'");
+
+            // Validate method is defined in an interface
+            var paramTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
+            var isInInterface = k.Item1.GetInterfaces().Any(iface =>
+                iface.GetMethod(method.Name, paramTypes) is { } m && m.ReturnType == method.ReturnType);
+
+            if (!isInInterface)
+            {
+                throw new InvalidOperationException(
+                    $"Method '{method.Name}' is not defined in any interface. " +
+                    $"Only methods defined in interfaces can be called via RPC.");
+            }
+
+            return method;
+        });
+    }
+
+    private static object?[] DeserializeArgs(
+        Google.Protobuf.Collections.RepeatedField<Any> protoArgs,
+        ParameterInfo[] paramInfos)
+    {
+        return paramInfos.Select((p, i) =>
+            i < protoArgs.Count ? ProtobufPacker.Unpack(protoArgs[i], p.ParameterType)
+            : p.HasDefaultValue ? p.DefaultValue : null).ToArray();
+    }
+
+    private static object? GetTaskResult(Task task)
+    {
+        return task.GetType().IsGenericType
+            ? task.GetType().GetProperty("Result")?.GetValue(task)
+            : null;
+    }
+}
+

--- a/src/Aevatar.Agents.Runtime.Local/LocalGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.Local/LocalGAgentActor.cs
@@ -241,4 +241,6 @@ public class LocalGAgentActor : GAgentActorBase
         var count = Interlocked.Decrement(ref _activeActorCount);
         AgentMetrics.UpdateActiveActorCount(count);
     }
+
+    // RPC: Inherited from GAgentActorBase (uses shared RpcInvoker)
 }

--- a/src/Aevatar.Agents.Runtime.Orleans/IGAgentGrain.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/IGAgentGrain.cs
@@ -77,4 +77,11 @@ public interface IGAgentGrain : IGrainWithStringKey
     /// 停用
     /// </summary>
     Task DeactivateAsync();
+
+    /// <summary>
+    /// Protobuf RPC method invocation
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    Task<byte[]> InvokeRpcAsync(byte[] requestBytes);
 }

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
@@ -1,6 +1,7 @@
 using Aevatar.Agents;
 using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.Core;
+using Aevatar.Agents.Rpc;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -257,6 +258,17 @@ public class OrleansGAgentActor : IGAgentActor
             "Agent instance is not available on client side. " +
             "In Orleans mode, Agent runs in Silo (Grain). " +
             "Use Grain RPC methods instead.");
+    }
+
+    /// <summary>
+    /// Invoke RPC method on Agent via Protobuf
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    public async Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
+    {
+        EnsureGrain();
+        return await _grain!.InvokeRpcAsync(requestBytes);
     }
 
     #endregion

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
@@ -3,7 +3,9 @@ using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.Abstractions.CQRS;
 using Aevatar.Agents.Core;
 using Aevatar.Agents.Core.Helpers;
+using Aevatar.Agents.Core.Rpc;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -228,10 +230,10 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
         }
     }
 
-    private Type? ResolveAgentType(string agentTypeName)
+    private System.Type? ResolveAgentType(string agentTypeName)
     {
         // Try direct type resolution
-        var type = Type.GetType(agentTypeName);
+        var type = System.Type.GetType(agentTypeName);
         if (type != null) return type;
 
         // Search all loaded assemblies
@@ -256,7 +258,7 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
         return null;
     }
 
-    private IGAgent? CreateAgentInstance(Type agentType, Guid agentId)
+    private IGAgent? CreateAgentInstance(System.Type agentType, Guid agentId)
     {
         try
         {
@@ -330,6 +332,12 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
 
         // Inject StateProjector
         StateProjectorInjector.InjectStateProjector(agent, ServiceProvider);
+
+        // Inject EventStore (only if agent supports EventSourcing)
+        if (AgentEventStoreInjector.HasEventStore(agent))
+        {
+            AgentEventStoreInjector.InjectEventStore(agent, ServiceProvider);
+        }
 
         // Inject EventPublisher (Grain acts as the publisher)
         AgentEventPublisherInjector.InjectEventPublisher(agent, new GrainEventPublisher(this, _myStream, _logger, GrainFactory));
@@ -498,6 +506,21 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
     {
         _logger.LogInformation("Grain {GrainId} deactivate requested", this.GetGrainId());
         return Task.CompletedTask;
+    }
+
+    #endregion
+
+    #region RPC Method Invocation
+
+    /// <summary>
+    /// Protobuf RPC method invocation - delegates to shared RpcInvoker
+    /// </summary>
+    public Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
+    {
+        if (_agent == null)
+            throw new InvalidOperationException("Agent not initialized");
+
+        return RpcInvoker.InvokeAsync(_agent, requestBytes, _logger);
     }
 
     #endregion

--- a/src/Aevatar.Agents.Runtime.ProtoActor/ProtoActorGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.ProtoActor/ProtoActorGAgentActor.cs
@@ -188,4 +188,6 @@ public class ProtoActorGAgentActor : GAgentActorBase
         AgentMetrics.UpdateActiveActorCount(count);
         Logger.LogDebug("Active actor count: {Count}", count);
     }
+
+    // RPC: Inherited from GAgentActorBase (uses shared RpcInvoker)
 }

--- a/test/Aevatar.Agents.Orleans.Tests/OrleansActorFactoryTests.cs
+++ b/test/Aevatar.Agents.Orleans.Tests/OrleansActorFactoryTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.Abstractions.Attributes;
+using Aevatar.Agents.Abstractions.Extensions;
 using Aevatar.Agents.AI.Core;
 using Aevatar.Agents.Core;
 using Aevatar.Agents.Core.Extensions;
@@ -205,6 +206,84 @@ public class OrleansActorFactoryTests : AevatarAgentsTestBase
             Assert.True(ids.Add(actor.Id), $"Duplicate actor ID found: {actor.Id}");
         }
     }
+
+    // ============ RPC Tests ============
+
+    [Fact]
+    public async Task RPC_Should_Invoke_Agent_Methods_Via_Interface()
+    {
+        // Arrange
+        var factory = CreateFactory(out _);
+        var agentId = Guid.NewGuid();
+        var actor = await factory.CreateGAgentActorAsync<OrleansRpcTestAgent>(agentId);
+
+        // Act - Use RPC extension methods
+        await actor.InvokeRpcAsync("SetMessageAsync", "Hello Orleans RPC!");
+        await actor.InvokeRpcAsync("IncrementAsync", 42);
+
+        var message = await actor.InvokeRpcAsync<string>("GetMessageAsync");
+        var count = await actor.InvokeRpcAsync<int>("GetCountAsync");
+
+        // Assert
+        Assert.Equal("Hello Orleans RPC!", message);
+        Assert.Equal(42, count);
+    }
+
+    [Fact]
+    public async Task RPC_Should_Handle_Multiple_Calls()
+    {
+        // Arrange
+        var factory = CreateFactory(out _);
+        var agentId = Guid.NewGuid();
+        var actor = await factory.CreateGAgentActorAsync<OrleansRpcTestAgent>(agentId);
+
+        // Act - Multiple increments
+        await actor.InvokeRpcAsync("IncrementAsync", 10);
+        await actor.InvokeRpcAsync("IncrementAsync", 20);
+        await actor.InvokeRpcAsync("IncrementAsync", 30);
+
+        var finalCount = await actor.InvokeRpcAsync<int>("GetCountAsync");
+
+        // Assert
+        Assert.Equal(60, finalCount);
+    }
+
+    [Fact]
+    public async Task RPC_Should_Reject_Non_Existent_Methods()
+    {
+        // Arrange
+        var factory = CreateFactory(out _);
+        var agentId = Guid.NewGuid();
+        var actor = await factory.CreateGAgentActorAsync<OrleansRpcTestAgent>(agentId);
+
+        // Act & Assert - Non-existent method should throw
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => actor.InvokeRpcAsync("SomeNonExistentMethod"));
+
+        Assert.Contains("RPC call failed", exception.Message);
+    }
+
+    [Fact]
+    public async Task RPC_Should_Handle_Concurrent_Calls()
+    {
+        // Arrange
+        var factory = CreateFactory(out _);
+        var agentId = Guid.NewGuid();
+        var actor = await factory.CreateGAgentActorAsync<OrleansRpcTestAgent>(agentId);
+
+        // Act - Concurrent RPC calls
+        var tasks = new List<Task>();
+        for (int i = 0; i < 10; i++)
+        {
+            tasks.Add(actor.InvokeRpcAsync("IncrementAsync", 1));
+        }
+        await Task.WhenAll(tasks);
+
+        var finalCount = await actor.InvokeRpcAsync<int>("GetCountAsync");
+
+        // Assert
+        Assert.Equal(10, finalCount);
+    }
 }
 
 // Test Agent Implementation for Orleans
@@ -256,4 +335,40 @@ public class OrleansTestAgent : GAgentBase<OrleansTestState>
     {
         GetState().IsDisposed = true;
     }
+}
+
+/// <summary>
+/// RPC-enabled test agent with interface
+/// </summary>
+public interface IOrleansRpcTestAgent : IGAgent
+{
+    Task<int> GetCountAsync();
+    Task IncrementAsync(int amount);
+    Task<string> GetMessageAsync();
+    Task SetMessageAsync(string message);
+}
+
+public class OrleansRpcTestAgent : GAgentBase<OrleansTestState>, IOrleansRpcTestAgent
+{
+    public OrleansRpcTestAgent() : base() { }
+    public OrleansRpcTestAgent(Guid id) : base(id) { }
+
+    public Task<int> GetCountAsync() => Task.FromResult(State.ProcessedCount);
+    
+    public Task IncrementAsync(int amount)
+    {
+        State.ProcessedCount += amount;
+        return Task.CompletedTask;
+    }
+
+    public Task<string> GetMessageAsync() => Task.FromResult(State.LastMessage ?? "");
+    
+    public Task SetMessageAsync(string message)
+    {
+        State.LastMessage = message;
+        return Task.CompletedTask;
+    }
+
+    public override Task<string> GetDescriptionAsync()
+        => Task.FromResult($"OrleansRpcTestAgent {Id}: Count={State.ProcessedCount}, Message={State.LastMessage}");
 }


### PR DESCRIPTION
…d invocation

- Add agent_rpc.proto with RpcRequest/RpcResponse/RpcError messages
- Add RpcInvoker for shared server-side RPC invocation logic
- Add ProtobufPacker for Protobuf Any packing/unpacking (supports decimal)
- Add RpcExtensions for client-side typed RPC calls
- Add InvokeRpcAsync to IGAgentActor interface
- Implement RPC in OrleansGAgentGrain with interface-based method validation
- Add EventStore injection to OrleansGAgentGrain (optional EventSourcing)
- Add IBankAccountAgent interface for RPC-callable methods
- Add Orleans RPC tests (4 tests passing)
- Update EventSourcingDemo with Orleans Runtime RPC demo (场景5)

RPC Design:
- Only methods defined in interfaces can be called via RPC
- Supports primitive types, decimal, and Protobuf messages
- VoidTaskResult handled correctly for void async methods