### PR TITLE
Make grain identity consistent for P2P

### DIFF
--- a/src/Aevatar.Agents.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Agents.Core/GAgentBase.TState.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Aevatar.Agents.Abstractions;
@@ -245,7 +245,8 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
         }
         else
         {
-            Logger?.LogWarning("OnStateChangedAsync called for agent {AgentId} ({AgentType}), but StateProjector is null", 
+            // StateProjector is optional. Logging this as Warning is too noisy and will flood logs.
+            Logger?.LogDebug("OnStateChangedAsync skipped projection for agent {AgentId} ({AgentType}) because StateProjector is null", 
                 Id, GetType().Name);
         }
     }
@@ -259,7 +260,7 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
     {
         if (StateProjector == null)
         {
-            Logger?.LogWarning("StateProjector not configured for agent {AgentId} ({AgentType}), state will not be projected", 
+            Logger?.LogDebug("StateProjector not configured for agent {AgentId} ({AgentType}), state will not be projected", 
                 Id, GetType().Name);
             return;
         }
@@ -557,7 +558,7 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
 
     // TODO: Read from configuration (EventSourcing:SnapshotFrequency)
     protected virtual ISnapshotStrategy SnapshotStrategy =>
-        new IntervalSnapshotStrategy(1);
+        new IntervalSnapshotStrategy(100);
 
     /// <summary>
     /// Create snapshot using StateStore (preferred) or EventStore (fallback)

--- a/src/Aevatar.Agents.Runtime.Orleans.MongoDB/MongoEventRepository.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans.MongoDB/MongoEventRepository.cs
@@ -58,7 +58,9 @@ public class MongoEventRepository : IEventRepository
     private readonly string _defaultCollectionName;
     private readonly MongoEventRepositoryOptions _options;
     private static readonly SemaphoreSlim _globalIndexLock = new(1, 1);
-    private static readonly HashSet<string> _indexedCollections = new();
+    // IMPORTANT: EnsureIndexesAsync can be called concurrently (fire-and-forget from constructors).
+    // Use a concurrent set to avoid HashSet race conditions.
+    private static readonly ConcurrentDictionary<string, byte> _indexedCollections = new();
 
     /// <summary>
     /// Creates a new MongoEventRepository with configuration options
@@ -159,14 +161,14 @@ public class MongoEventRepository : IEventRepository
         CancellationToken ct = default)
     {
         // Check if this collection has already been indexed
-        if (_indexedCollections.Contains(collectionName))
+        if (_indexedCollections.ContainsKey(collectionName))
             return;
 
         await _globalIndexLock.WaitAsync(ct);
         try
         {
             // Double-check after acquiring lock
-            if (_indexedCollections.Contains(collectionName))
+            if (_indexedCollections.ContainsKey(collectionName))
                 return;
 
             var indexModels = new List<CreateIndexModel<EventDocument>>();
@@ -216,7 +218,7 @@ public class MongoEventRepository : IEventRepository
             // Batch create all indexes
             await collection.Indexes.CreateManyAsync(indexModels, ct);
 
-            _indexedCollections.Add(collectionName);
+            _indexedCollections.TryAdd(collectionName, 0);
             
             _logger.LogInformation(
                 "MongoDB indexes created for collection '{Collection}': agentId+version DESC (UNIQUE), timestamp, eventType",
@@ -229,7 +231,7 @@ public class MongoEventRepository : IEventRepository
                 collectionName);
             
             // Mark as indexed even on failure to avoid retry storms
-            _indexedCollections.Add(collectionName);
+            _indexedCollections.TryAdd(collectionName, 0);
         }
         finally
         {

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
@@ -74,10 +74,13 @@ public class OrleansGAgentActor : IGAgentActor, IActorHierarchyOperations
         Logger.LogInformation("Activating Orleans Actor proxy {ActorId}, AgentType: {AgentType}", _id, _agentTypeName);
 
         // Get non-generic Grain reference
-        // Grain ID = AgentTypeShortName:AgentId (to ensure different Agent types use different Grains)
-        // Business State sharding is handled by IStateStore<TState>, not Orleans Grain
-        var agentTypeShortName = GetAgentTypeShortName(_agentTypeName);
-        var grainId = $"{agentTypeShortName}:{_id}";
+        // Grain ID = AgentId (string).
+        // Business state sharding is handled by IStateStore<TState>, not by Grain key.
+        //
+        // IMPORTANT:
+        // P2P routing only has targetAgentId, so Grain key MUST be derivable from agentId alone.
+        // Using "Type:Id" would create inconsistent identities and break event-sourcing consistency.
+        var grainId = _id.ToString();
         _grain = _grainFactory.GetGrain<IGAgentGrain>(grainId);
 
         // Initialize Agent in Grain (Silo side)
@@ -283,22 +286,8 @@ public class OrleansGAgentActor : IGAgentActor, IActorHierarchyOperations
     {
         if (_grain == null)
         {
-            var agentTypeShortName = GetAgentTypeShortName(_agentTypeName);
-            var grainId = $"{agentTypeShortName}:{_id}";
-            _grain = _grainFactory.GetGrain<IGAgentGrain>(grainId);
+            _grain = _grainFactory.GetGrain<IGAgentGrain>(_id.ToString());
         }
-    }
-
-    /// <summary>
-    /// Extract short type name from assembly qualified name
-    /// Example: "Aevatar.App.Agents.UserQuotaGAgent, Aevatar.App.Agents" -> "UserQuotaGAgent"
-    /// </summary>
-    private static string GetAgentTypeShortName(string agentTypeName)
-    {
-        // Extract class name from assembly qualified name
-        var fullName = agentTypeName.Split(',')[0].Trim();
-        var lastDot = fullName.LastIndexOf('.');
-        return lastDot >= 0 ? fullName.Substring(lastDot + 1) : fullName;
     }
 
     /// <summary>

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
@@ -177,8 +177,11 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
 
     public Task<bool> InitializeAgentAsync(string agentTypeName)
     {
-        // Grain ID format: "AgentTypeShortName:AgentId" (e.g., "UserQuotaGAgent:abc123-...")
-        // Extract Agent ID from Grain's PrimaryKey
+        // Grain Key format:
+        // - Preferred: "AgentId" (string guid)  ✅ consistent with P2P routing (targetAgentId only)
+        // - Backward compatible: "AgentTypeShortName:AgentId"
+        //
+        // Always extract AgentId from the Grain key for consistency.
         var grainKey = this.GetPrimaryKeyString();
         var agentId = ExtractAgentIdFromGrainKey(grainKey);
         return InitializeAgentInternalAsync(agentTypeName, agentId, persistState: true);
@@ -487,12 +490,16 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
 
     public Task<Guid> GetIdAsync()
     {
-        var keyString = this.GetPrimaryKeyString();
-        if (Guid.TryParse(keyString, out var guid))
+        var grainKey = this.GetPrimaryKeyString();
+        try
         {
-            return Task.FromResult(guid);
+            return Task.FromResult(ExtractAgentIdFromGrainKey(grainKey));
         }
-        return Task.FromResult(Guid.Empty);
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse AgentId from Grain key '{GrainKey}'", grainKey);
+            return Task.FromResult(Guid.Empty);
+        }
     }
 
     public async Task AddChildAsync(Guid childId)


### PR DESCRIPTION
Ensure Orleans Grain keys are derived from agentId so P2P SendTo targets the same identity, harden MongoEventRepository index guards for concurrent startup, and reduce noisy CQRS projection logging.