### PR TITLE
Knowledge graph DAG client enhancement

### DIFF
--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -1,0 +1,184 @@
+---
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Non-Functional Requirements
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: Each functional + non-functional requirement with a stable key (derive slug based on imperative phrase; e.g., "User can upload file" → `user-can-upload-file`)
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Non-functional requirements not reflected in tasks (e.g., performance, security)
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit.implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -1,0 +1,294 @@
+---
+description: Generate a custom checklist for the current feature based on user requirements.
+---
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+     - If file exists, append to existing file
+   - Number items sequentially starting from CHK001
+   - Each `/speckit.checklist` run creates a NEW file (never overwrites existing checklists)
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"

--- a/.claude/commands/speckit.clarify.md
+++ b/.claude/commands/speckit.clarify.md
@@ -1,0 +1,177 @@
+---
+description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 10 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Non-Functional / Quality Attributes section (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -1,0 +1,78 @@
+---
+description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+Follow this execution flow:
+
+1. Load the existing constitution template at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -1,0 +1,134 @@
+---
+description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc*or eslint.config.* exists → create/verify .eslintignore
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -1,0 +1,81 @@
+---
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Agent context update**:
+   - Run `.specify/scripts/bash/update-agent-context.sh cursor-agent`
+   - These scripts detect which AI agent is in use
+   - Update the appropriate agent-specific context file
+   - Add only new technology from current plan
+   - Preserve manual additions between markers
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+## Key rules
+
+- Use absolute paths
+- ERROR on gate failures or unresolved clarifications

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -1,0 +1,249 @@
+---
+description: Create or update the feature specification from a natural language feature description.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the branch:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Check for existing branches before creating new one**:
+   
+   a. First, fetch all remote branches to ensure we have the latest information:
+      ```bash
+      git fetch --all --prune
+      ```
+   
+   b. Find the highest feature number across all sources for the short-name:
+      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
+      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
+      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+   
+   c. Determine the next available number:
+      - Extract all numbers from all three sources
+      - Find the highest number N
+      - Use N+1 for the new branch number
+   
+   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
+      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   
+   **IMPORTANT**:
+   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
+   - Only match branches/directories with the exact short-name pattern
+   - If no existing branches/directories found with this short-name, start with number 1
+   - You must only ever run this script once per feature
+   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
+   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+
+3. Load `.specify/templates/spec-template.md` to understand required sections.
+
+4. Follow this execution flow:
+
+    1. Parse user description from Input
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 6
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+
+## General Guidelines
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: RESTful APIs unless specified otherwise
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -1,0 +1,128 @@
+---
+description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map endpoints to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Endpoints/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each contract/endpoint → to the user story it serves
+   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,6 +62,8 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.5.2" />
     <!-- Neo4j -->
     <PackageVersion Include="Neo4j.Driver" Version="5.25.0" />
+    <!-- S3 Compatible Storage -->
+    <PackageVersion Include="Minio" Version="6.0.4" />
     <!-- Elasticsearch -->
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.17.3" />
     <PackageVersion Include="Elastic.Transport" Version="0.5.9" />

--- a/src/Aevatar.Agents.Knowledge.Graph/Aevatar.Agents.Knowledge.Graph.csproj
+++ b/src/Aevatar.Agents.Knowledge.Graph/Aevatar.Agents.Knowledge.Graph.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Minio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aevatar.Agents.Persistence.Graph\Aevatar.Agents.Persistence.Graph.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aevatar.Agents.Knowledge.Graph/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,99 @@
+using Aevatar.Agents.Knowledge.Graph.Storage;
+using Aevatar.Agents.Knowledge.Graph.Store;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Minio;
+
+namespace Aevatar.Agents.Knowledge.Graph;
+
+/// <summary>
+/// Extension methods for registering knowledge graph services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the knowledge graph services with optional S3 storage.
+    /// Requires an IGraphClient to already be registered (e.g., via AddAevatarGraphInMemory or AddAevatarGraphNeo4j).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// // Setup with in-memory storage (no S3)
+    /// services.AddAevatarGraphInMemory();
+    /// services.AddKnowledgeGraph();
+    ///
+    /// // Or with S3 storage
+    /// services.AddAevatarGraphInMemory();
+    /// services.AddKnowledgeGraph(options =>
+    /// {
+    ///     options.Endpoint = "play.min.io";
+    ///     options.AccessKey = "your-access-key";
+    ///     options.SecretKey = "your-secret-key";
+    ///     options.BucketName = "knowledge-graph";
+    /// });
+    ///
+    /// // Usage - create session-scoped clients
+    /// var factory = sp.GetRequiredService&lt;IKnowledgeGraphClientFactory&gt;();
+    /// var client = factory.CreateClient("session-123");
+    /// await client.AddNodeAsync("axiom-1", KnowledgeNodeType.MathAxiom,
+    ///     "Base case axiom", "The foundational axiom for the proof.");
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddKnowledgeGraph(this IServiceCollection services)
+    {
+        // Use NullFileStorage by default (no S3)
+        services.TryAddSingleton<IFileStorage, NullFileStorage>();
+        services.TryAddSingleton<IKnowledgeGraphStore, GraphClientBackedStore>();
+        services.TryAddSingleton<IKnowledgeGraphClientFactory, KnowledgeGraphClientFactory>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the knowledge graph services with S3 storage configuration.
+    /// Requires an IGraphClient to already be registered (e.g., via AddAevatarGraphInMemory or AddAevatarGraphNeo4j).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">Action to configure S3 storage options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddKnowledgeGraph(
+        this IServiceCollection services,
+        Action<S3StorageOptions> configureOptions)
+    {
+        var options = new S3StorageOptions();
+        configureOptions(options);
+
+        // Register options
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(options));
+
+        // Register Minio client
+        services.AddSingleton<IMinioClient>(_ =>
+        {
+            var builder = new MinioClient()
+                .WithEndpoint(options.Endpoint)
+                .WithCredentials(options.AccessKey, options.SecretKey);
+
+            if (!string.IsNullOrWhiteSpace(options.Region))
+            {
+                builder = builder.WithRegion(options.Region);
+            }
+
+            if (options.UseSsl)
+            {
+                builder = builder.WithSSL();
+            }
+
+            return builder.Build();
+        });
+
+        // Register logger if not already registered
+        services.TryAddSingleton<ILogger<S3FileStorage>>(_ => NullLogger<S3FileStorage>.Instance);
+
+        services.AddSingleton<IFileStorage, S3FileStorage>();
+        services.TryAddSingleton<IKnowledgeGraphStore, GraphClientBackedStore>();
+        services.TryAddSingleton<IKnowledgeGraphClientFactory, KnowledgeGraphClientFactory>();
+        return services;
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Exceptions/CycleDetectedException.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Exceptions/CycleDetectedException.cs
@@ -1,0 +1,30 @@
+namespace Aevatar.Agents.Knowledge.Graph.Exceptions;
+
+/// <summary>
+/// Thrown when adding a dependency would create a cycle in the directed acyclic graph (DAG).
+/// Knowledge graphs must remain acyclic to maintain valid inference chains.
+/// </summary>
+public sealed class CycleDetectedException : Exception
+{
+    /// <summary>
+    /// Gets the ID of the node that would be the source of the cycle.
+    /// </summary>
+    public string FromNodeId { get; }
+
+    /// <summary>
+    /// Gets the ID of the node that would be the target of the dependency creating the cycle.
+    /// </summary>
+    public string ToNodeId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CycleDetectedException"/> class.
+    /// </summary>
+    /// <param name="fromNodeId">The source node ID.</param>
+    /// <param name="toNodeId">The target node ID that would create a cycle.</param>
+    public CycleDetectedException(string fromNodeId, string toNodeId)
+        : base($"Adding dependency from '{fromNodeId}' to '{toNodeId}' would create a cycle.")
+    {
+        FromNodeId = fromNodeId;
+        ToNodeId = toNodeId;
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Exceptions/DuplicateNodeException.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Exceptions/DuplicateNodeException.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.Agents.Knowledge.Graph.Exceptions;
+
+/// <summary>
+/// Thrown when attempting to add a node with an ID that already exists.
+/// </summary>
+public sealed class DuplicateNodeException : Exception
+{
+    /// <summary>
+    /// Gets the ID of the duplicate node.
+    /// </summary>
+    public string NodeId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuplicateNodeException"/> class.
+    /// </summary>
+    /// <param name="nodeId">The ID of the duplicate node.</param>
+    public DuplicateNodeException(string nodeId)
+        : base($"A node with ID '{nodeId}' already exists.")
+    {
+        NodeId = nodeId;
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Exceptions/NodeNotFoundException.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Exceptions/NodeNotFoundException.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.Agents.Knowledge.Graph.Exceptions;
+
+/// <summary>
+/// Thrown when a referenced knowledge node does not exist in the graph.
+/// </summary>
+public sealed class NodeNotFoundException : Exception
+{
+    /// <summary>
+    /// Gets the ID of the node that was not found.
+    /// </summary>
+    public string NodeId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NodeNotFoundException"/> class.
+    /// </summary>
+    /// <param name="nodeId">The ID of the node that was not found.</param>
+    public NodeNotFoundException(string nodeId)
+        : base($"Node '{nodeId}' not found.")
+    {
+        NodeId = nodeId;
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/IKnowledgeGraphClient.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/IKnowledgeGraphClient.cs
@@ -1,0 +1,94 @@
+using Aevatar.Agents.Knowledge.Graph.Models;
+
+namespace Aevatar.Agents.Knowledge.Graph;
+
+/// <summary>
+/// Knowledge graph client interface for scientific research assistants.
+/// Each client instance is scoped to a specific session for isolation.
+/// </summary>
+public interface IKnowledgeGraphClient
+{
+    /// <summary>
+    /// The session ID this client operates on.
+    /// All operations are isolated to this session.
+    /// </summary>
+    string SessionId { get; }
+
+    /// <summary>
+    /// Adds a knowledge node to the graph.
+    /// If resourceFolderPath points to a local folder, it will be zipped and uploaded to S3.
+    /// </summary>
+    /// <param name="nodeId">Unique identifier for the node within this session.</param>
+    /// <param name="nodeType">Type of knowledge (e.g., MathAxiom, BiologyExperiment).</param>
+    /// <param name="coreDescription">Core description - concise summary of the key conclusion.</param>
+    /// <param name="detailedDescription">Detailed description - comprehensive explanation.</param>
+    /// <param name="proof">Optional proof in Markdown format.</param>
+    /// <param name="resourceFolderPath">Optional local folder path containing resources to zip and upload to S3.</param>
+    /// <param name="dependsOn">Optional IDs of existing nodes this node depends on (inference relationship).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created node with ResourceUri if folder was uploaded.</returns>
+    /// <exception cref="Exceptions.DuplicateNodeException">Thrown if a node with the same ID already exists.</exception>
+    /// <exception cref="Exceptions.NodeNotFoundException">Thrown if any dependency node does not exist.</exception>
+    /// <exception cref="Exceptions.CycleDetectedException">Thrown if adding this node would create a cycle.</exception>
+    Task<KnowledgeNode> AddNodeAsync(
+        string nodeId,
+        KnowledgeNodeType nodeType,
+        string coreDescription,
+        string detailedDescription,
+        string? proof = null,
+        string? resourceFolderPath = null,
+        IEnumerable<string>? dependsOn = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a complete snapshot of the graph (all nodes with full information and edges within current session).
+    /// </summary>
+    Task<KnowledgeSnapshot> GetKnowledgeSnapshotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the complete knowledge chain details for a node by traversing all its upstream dependencies.
+    /// Returns both the structured chain and a human-readable Markdown description.
+    /// </summary>
+    /// <param name="nodeId">The node to get the chain details for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="KnowledgeChainDetails"/> containing:
+    /// - The structured <see cref="KnowledgeChain"/> with nodes organized by inference levels
+    /// - A Markdown-formatted description as a mini research paper
+    /// </returns>
+    /// <exception cref="Exceptions.NodeNotFoundException">Thrown if the node does not exist.</exception>
+    Task<KnowledgeChainDetails> GetKnowledgeChainDetailsAsync(string nodeId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a comprehensive research paper in Markdown format from the entire knowledge snapshot.
+    /// Includes all knowledge nodes (CoreDescription, DetailedDescription, Proof, ResourceUri)
+    /// organized by inference relationships into a coherent paper structure.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Markdown formatted comprehensive research paper.</returns>
+    Task<string> GenerateFullPaperAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a node by its ID (within current session).
+    /// </summary>
+    Task<KnowledgeNode?> GetNodeAsync(string nodeId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a node from the graph.
+    /// Also removes all edges connected to this node and deletes associated S3 files.
+    /// </summary>
+    Task<bool> RemoveNodeAsync(string nodeId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Factory for creating session-scoped knowledge graph clients.
+/// </summary>
+public interface IKnowledgeGraphClientFactory
+{
+    /// <summary>
+    /// Creates a knowledge graph client for the specified session.
+    /// </summary>
+    /// <param name="sessionId">The session ID for isolation.</param>
+    /// <returns>A client scoped to the session.</returns>
+    IKnowledgeGraphClient CreateClient(string sessionId);
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/KnowledgeGraphClient.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/KnowledgeGraphClient.cs
@@ -1,0 +1,581 @@
+using System.Text;
+using Aevatar.Agents.Knowledge.Graph.Exceptions;
+using Aevatar.Agents.Knowledge.Graph.Models;
+using Aevatar.Agents.Knowledge.Graph.Storage;
+using Aevatar.Agents.Knowledge.Graph.Store;
+using Aevatar.Agents.Knowledge.Graph.Validation;
+
+namespace Aevatar.Agents.Knowledge.Graph;
+
+/// <summary>
+/// Main implementation of the knowledge graph client for scientific research assistants.
+/// Each instance is scoped to a specific session.
+/// </summary>
+internal sealed class KnowledgeGraphClient : IKnowledgeGraphClient
+{
+    private readonly IKnowledgeGraphStore _store;
+    private readonly IFileStorage _fileStorage;
+    private readonly DagValidator _dagValidator;
+
+    public string SessionId { get; }
+
+    public KnowledgeGraphClient(string sessionId, IKnowledgeGraphStore store, IFileStorage fileStorage)
+    {
+        SessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
+        _store = store;
+        _fileStorage = fileStorage;
+        _dagValidator = new DagValidator(store);
+    }
+
+    public async Task<KnowledgeNode> AddNodeAsync(
+        string nodeId,
+        KnowledgeNodeType nodeType,
+        string coreDescription,
+        string detailedDescription,
+        string? proof = null,
+        string? resourceFolderPath = null,
+        IEnumerable<string>? dependsOn = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(coreDescription);
+        ArgumentException.ThrowIfNullOrWhiteSpace(detailedDescription);
+
+        // Check for duplicate
+        if (await _dagValidator.NodeExistsAsync(SessionId, nodeId, cancellationToken))
+        {
+            throw new DuplicateNodeException(nodeId);
+        }
+
+        var dependsOnList = dependsOn?.ToList() ?? [];
+
+        // Validate all dependencies exist
+        foreach (var depId in dependsOnList)
+        {
+            if (!await _dagValidator.NodeExistsAsync(SessionId, depId, cancellationToken))
+            {
+                throw new NodeNotFoundException(depId);
+            }
+        }
+
+        // Validate no cycle would be created
+        if (dependsOnList.Count > 0)
+        {
+            var isValid = await _dagValidator.ValidateNoCycleAsync(SessionId, nodeId, dependsOnList, cancellationToken);
+            if (!isValid)
+            {
+                throw new CycleDetectedException(nodeId, dependsOnList[0]);
+            }
+        }
+
+        // Upload folder to S3 if provided (folder will be zipped)
+        string? resourceUri = null;
+        if (!string.IsNullOrWhiteSpace(resourceFolderPath) && Directory.Exists(resourceFolderPath))
+        {
+            resourceUri = await _fileStorage.UploadFolderAsync(SessionId, resourceFolderPath, null, cancellationToken);
+        }
+
+        var node = new KnowledgeNode
+        {
+            Id = nodeId,
+            SessionId = SessionId,
+            NodeType = nodeType,
+            CoreDescription = coreDescription,
+            DetailedDescription = detailedDescription,
+            Proof = proof,
+            ResourceFolderPath = resourceFolderPath,
+            ResourceUri = resourceUri,
+            Timestamp = DateTimeOffset.UtcNow,
+            DependsOn = dependsOnList
+        };
+
+        await _store.AddNodeAsync(node, cancellationToken);
+
+        // Add edges: node -[DEPENDS_ON]-> dependency
+        foreach (var depId in dependsOnList)
+        {
+            await _store.AddEdgeAsync(new KnowledgeEdge
+            {
+                FromId = nodeId,
+                ToId = depId,
+                CreatedAt = DateTimeOffset.UtcNow
+            }, SessionId, cancellationToken);
+        }
+
+        return node;
+    }
+
+    public async Task<KnowledgeSnapshot> GetKnowledgeSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var nodes = await _store.GetAllNodesAsync(SessionId, cancellationToken);
+        var edges = await _store.GetAllEdgesAsync(SessionId, cancellationToken);
+
+        return new KnowledgeSnapshot
+        {
+            SessionId = SessionId,
+            Nodes = nodes.OrderBy(n => n.NodeType).ThenBy(n => n.Id).ToList(),
+            Edges = edges.OrderBy(e => e.FromId).ThenBy(e => e.ToId).ToList()
+        };
+    }
+
+    private async Task<KnowledgeChain> GetKnowledgeChainAsync(string nodeId, CancellationToken cancellationToken = default)
+    {
+        var targetNode = await _store.GetNodeAsync(SessionId, nodeId, cancellationToken);
+        if (targetNode == null)
+        {
+            throw new NodeNotFoundException(nodeId);
+        }
+
+        // BFS to build levels
+        var levels = new List<KnowledgeChainLevel>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var chain = new List<KnowledgeNode>();
+        var currentLevel = new List<string> { nodeId };
+
+        while (currentLevel.Count > 0)
+        {
+            var levelNodes = new List<KnowledgeNode>();
+
+            foreach (var id in currentLevel)
+            {
+                if (!visited.Add(id)) continue;
+
+                var node = await _store.GetNodeAsync(SessionId, id, cancellationToken);
+                if (node != null)
+                {
+                    levelNodes.Add(node);
+                    chain.Add(node);
+                }
+            }
+
+            if (levelNodes.Count > 0)
+            {
+                levels.Add(new KnowledgeChainLevel
+                {
+                    Depth = levels.Count,
+                    Nodes = levelNodes
+                });
+            }
+
+            // Get next level (dependencies of current level)
+            var nextLevel = new List<string>();
+            foreach (var id in currentLevel)
+            {
+                var deps = await _store.GetDependenciesAsync(SessionId, id, cancellationToken);
+                foreach (var dep in deps)
+                {
+                    if (!visited.Contains(dep))
+                    {
+                        nextLevel.Add(dep);
+                    }
+                }
+            }
+            currentLevel = nextLevel;
+        }
+
+        return new KnowledgeChain
+        {
+            SessionId = SessionId,
+            TargetNode = targetNode,
+            Levels = levels,
+            Chain = chain
+        };
+    }
+
+    public async Task<KnowledgeChainDetails> GetKnowledgeChainDetailsAsync(string nodeId, CancellationToken cancellationToken = default)
+    {
+        var chain = await GetKnowledgeChainAsync(nodeId, cancellationToken);
+        var description = FormatKnowledgePaper(chain);
+        return new KnowledgeChainDetails
+        {
+            Chain = chain,
+            Description = description
+        };
+    }
+
+    public async Task<string> GenerateFullPaperAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await GetKnowledgeSnapshotAsync(cancellationToken);
+        return FormatFullPaper(snapshot);
+    }
+
+    private static string FormatKnowledgePaper(KnowledgeChain chain)
+    {
+        var sb = new StringBuilder();
+
+        // Title
+        sb.AppendLine($"# {chain.TargetNode.CoreDescription}");
+        sb.AppendLine();
+        sb.AppendLine($"**Generated**: {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+        sb.AppendLine($"**Knowledge Chain Depth**: {chain.MaxDepth + 1} levels");
+        sb.AppendLine($"**Total Knowledge Nodes**: {chain.TotalNodes}");
+        sb.AppendLine();
+
+        // Abstract - explain target node and derivation chain
+        sb.AppendLine("## Abstract");
+        sb.AppendLine();
+        sb.AppendLine($"This paper presents the derivation chain for **{chain.TargetNode.CoreDescription}** (ID: `{chain.TargetNode.Id}`), ");
+        sb.AppendLine($"a {chain.TargetNode.NodeType} in the knowledge graph.");
+        sb.AppendLine();
+        sb.AppendLine($"{chain.TargetNode.DetailedDescription}");
+        sb.AppendLine();
+
+        // Build derivation summary
+        var foundationNodes = chain.Levels.Where(l => l.Depth == chain.MaxDepth).SelectMany(l => l.Nodes).ToList();
+        if (foundationNodes.Count > 0)
+        {
+            sb.AppendLine("### Derivation Path");
+            sb.AppendLine();
+            sb.AppendLine("This knowledge is derived through the following reasoning chain:");
+            sb.AppendLine();
+
+            // Show derivation path from foundation to target
+            foreach (var level in chain.Levels.AsEnumerable().Reverse())
+            {
+                var levelName = level.Depth == chain.MaxDepth ? "Foundation" :
+                                level.Depth == 0 ? "Target" :
+                                $"Level {chain.MaxDepth - level.Depth}";
+                var nodeNames = string.Join(", ", level.Nodes.Select(n => n.CoreDescription));
+                sb.AppendLine($"- **{levelName}**: {nodeNames}");
+            }
+            sb.AppendLine();
+        }
+
+        // Table of Contents
+        sb.AppendLine("## Table of Contents");
+        sb.AppendLine();
+        var sectionNum = 1;
+        foreach (var level in chain.Levels.AsEnumerable().Reverse())
+        {
+            foreach (var node in level.Nodes)
+            {
+                sb.AppendLine($"{sectionNum}. [{node.CoreDescription}](#{ToAnchor(node.Id)})");
+                sectionNum++;
+            }
+        }
+        sb.AppendLine();
+
+        // Knowledge Nodes - from foundation to target
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Knowledge Nodes");
+        sb.AppendLine();
+
+        sectionNum = 1;
+        foreach (var level in chain.Levels.AsEnumerable().Reverse())
+        {
+            var levelLabel = level.Depth == chain.MaxDepth ? "Foundation" :
+                             level.Depth == 0 ? "Conclusion" :
+                             $"Derivation Level {chain.MaxDepth - level.Depth}";
+
+            sb.AppendLine($"### {levelLabel}");
+            sb.AppendLine();
+
+            foreach (var node in level.Nodes)
+            {
+                // Node header
+                sb.AppendLine($"#### {sectionNum}. {node.CoreDescription} {{#{ToAnchor(node.Id)}}}");
+                sb.AppendLine();
+
+                // Basic info table
+                sb.AppendLine("| Property | Value |");
+                sb.AppendLine("|----------|-------|");
+                sb.AppendLine($"| **ID** | `{node.Id}` |");
+                sb.AppendLine($"| **Type** | {node.NodeType} |");
+                sb.AppendLine();
+
+                // Core Description
+                sb.AppendLine("**Core Description**");
+                sb.AppendLine();
+                sb.AppendLine($"> {node.CoreDescription}");
+                sb.AppendLine();
+
+                // Detailed Description
+                if (!string.IsNullOrWhiteSpace(node.DetailedDescription))
+                {
+                    sb.AppendLine("**Detailed Description**");
+                    sb.AppendLine();
+                    sb.AppendLine(node.DetailedDescription);
+                    sb.AppendLine();
+                }
+
+                // Proof
+                if (!string.IsNullOrWhiteSpace(node.Proof))
+                {
+                    sb.AppendLine("**Proof**");
+                    sb.AppendLine();
+                    sb.AppendLine("```");
+                    sb.AppendLine(node.Proof);
+                    sb.AppendLine("```");
+                    sb.AppendLine();
+                }
+
+                // Dependencies
+                if (node.DependsOn.Count > 0)
+                {
+                    sb.AppendLine("**Depends On**");
+                    sb.AppendLine();
+                    foreach (var depId in node.DependsOn)
+                    {
+                        var depNode = chain.Chain.FirstOrDefault(n => n.Id == depId);
+                        if (depNode != null)
+                        {
+                            sb.AppendLine($"- [{depNode.CoreDescription}](#{ToAnchor(depId)}) (`{depId}`)");
+                        }
+                        else
+                        {
+                            sb.AppendLine($"- `{depId}`");
+                        }
+                    }
+                    sb.AppendLine();
+                }
+
+                // Resource URI
+                if (!string.IsNullOrWhiteSpace(node.ResourceUri))
+                {
+                    sb.AppendLine("**Resources**");
+                    sb.AppendLine();
+                    sb.AppendLine($"- [Download Resource Files]({node.ResourceUri})");
+                    sb.AppendLine();
+                }
+
+                sb.AppendLine("---");
+                sb.AppendLine();
+                sectionNum++;
+            }
+        }
+
+        // References section
+        sb.AppendLine("## References");
+        sb.AppendLine();
+        var refNum = 1;
+        foreach (var node in chain.Chain.Where(n => !string.IsNullOrWhiteSpace(n.ResourceUri)))
+        {
+            sb.AppendLine($"[{refNum}] **{node.CoreDescription}** (`{node.Id}`)");
+            sb.AppendLine($"    - {node.ResourceUri}");
+            sb.AppendLine();
+            refNum++;
+        }
+        if (refNum == 1)
+        {
+            sb.AppendLine("*No external resources attached to this knowledge chain.*");
+        }
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    private static string FormatFullPaper(KnowledgeSnapshot snapshot)
+    {
+        var sb = new StringBuilder();
+
+        // Find root nodes (no dependencies - foundation knowledge)
+        var rootNodes = snapshot.Nodes.Where(n => n.DependsOn.Count == 0).ToList();
+
+        // Find leaf nodes (no nodes depend on them - final conclusions)
+        var nodeIdsWithDependents = snapshot.Edges.Select(e => e.ToId).ToHashSet();
+        var leafNodes = snapshot.Nodes.Where(n => !nodeIdsWithDependents.Contains(n.Id)).ToList();
+
+        // Title
+        sb.AppendLine("# Knowledge Graph Research Paper");
+        sb.AppendLine();
+        sb.AppendLine($"**Session**: {snapshot.SessionId}");
+        sb.AppendLine($"**Generated**: {DateTimeOffset.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+        sb.AppendLine($"**Total Knowledge Nodes**: {snapshot.NodeCount}");
+        sb.AppendLine($"**Total Inference Relationships**: {snapshot.EdgeCount}");
+        sb.AppendLine();
+
+        // Abstract
+        sb.AppendLine("## Abstract");
+        sb.AppendLine();
+        sb.AppendLine("This paper presents a comprehensive knowledge graph containing interconnected scientific knowledge. ");
+        sb.AppendLine($"The graph consists of {snapshot.NodeCount} knowledge nodes connected by {snapshot.EdgeCount} inference relationships, ");
+        sb.AppendLine($"with {rootNodes.Count} foundational axioms/definitions and {leafNodes.Count} derived conclusions.");
+        sb.AppendLine();
+
+        // Table of Contents by Type
+        sb.AppendLine("## Knowledge Overview");
+        sb.AppendLine();
+        var nodesByType = snapshot.Nodes.GroupBy(n => n.NodeType).OrderBy(g => g.Key);
+        foreach (var group in nodesByType)
+        {
+            sb.AppendLine($"### {group.Key} ({group.Count()})");
+            sb.AppendLine();
+            foreach (var node in group)
+            {
+                sb.AppendLine($"- [{node.CoreDescription}](#{ToAnchor(node.Id)})");
+            }
+            sb.AppendLine();
+        }
+
+        // Build topological order for proper presentation
+        var sortedNodes = TopologicalSort(snapshot);
+
+        // Content sections
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Detailed Knowledge");
+        sb.AppendLine();
+
+        var sectionNum = 1;
+        foreach (var node in sortedNodes)
+        {
+            sb.AppendLine($"### {sectionNum}. {node.CoreDescription} {{#{ToAnchor(node.Id)}}}");
+            sb.AppendLine();
+            sb.AppendLine($"**Type**: {node.NodeType}");
+            sb.AppendLine($"**ID**: `{node.Id}`");
+            sb.AppendLine($"**Timestamp**: {node.Timestamp:yyyy-MM-dd HH:mm:ss}");
+            sb.AppendLine();
+
+            // Core Description
+            sb.AppendLine("#### Summary");
+            sb.AppendLine();
+            sb.AppendLine(node.CoreDescription);
+            sb.AppendLine();
+
+            // Detailed Description
+            sb.AppendLine("#### Detailed Description");
+            sb.AppendLine();
+            sb.AppendLine(node.DetailedDescription);
+            sb.AppendLine();
+
+            // Proof
+            if (!string.IsNullOrWhiteSpace(node.Proof))
+            {
+                sb.AppendLine("#### Proof");
+                sb.AppendLine();
+                sb.AppendLine(node.Proof);
+                sb.AppendLine();
+            }
+
+            // Dependencies
+            if (node.DependsOn.Count > 0)
+            {
+                sb.AppendLine("#### Based On");
+                sb.AppendLine();
+                foreach (var depId in node.DependsOn)
+                {
+                    var depNode = snapshot.Nodes.FirstOrDefault(n => n.Id == depId);
+                    if (depNode != null)
+                    {
+                        sb.AppendLine($"- [{depNode.CoreDescription}](#{ToAnchor(depId)})");
+                    }
+                }
+                sb.AppendLine();
+            }
+
+            // Resource
+            if (!string.IsNullOrWhiteSpace(node.ResourceUri))
+            {
+                sb.AppendLine("#### Resources");
+                sb.AppendLine();
+                sb.AppendLine($"- [Download Resources]({node.ResourceUri})");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sectionNum++;
+        }
+
+        // References
+        sb.AppendLine("## References");
+        sb.AppendLine();
+        var refNum = 1;
+        foreach (var node in snapshot.Nodes.Where(n => !string.IsNullOrWhiteSpace(n.ResourceUri)))
+        {
+            sb.AppendLine($"[{refNum}] {node.CoreDescription}: {node.ResourceUri}");
+            refNum++;
+        }
+        if (refNum == 1)
+        {
+            sb.AppendLine("*No external resources attached.*");
+        }
+
+        return sb.ToString();
+    }
+
+    private static List<KnowledgeNode> TopologicalSort(KnowledgeSnapshot snapshot)
+    {
+        var result = new List<KnowledgeNode>();
+        var visited = new HashSet<string>();
+        var nodeMap = snapshot.Nodes.ToDictionary(n => n.Id);
+
+        void Visit(string nodeId)
+        {
+            if (visited.Contains(nodeId)) return;
+            visited.Add(nodeId);
+
+            if (nodeMap.TryGetValue(nodeId, out var node))
+            {
+                // Visit dependencies first
+                foreach (var depId in node.DependsOn)
+                {
+                    Visit(depId);
+                }
+                result.Add(node);
+            }
+        }
+
+        foreach (var node in snapshot.Nodes)
+        {
+            Visit(node.Id);
+        }
+
+        return result;
+    }
+
+    private static string ToAnchor(string id) => id.ToLowerInvariant().Replace(" ", "-");
+
+    public Task<KnowledgeNode?> GetNodeAsync(string nodeId, CancellationToken cancellationToken = default)
+    {
+        return _store.GetNodeAsync(SessionId, nodeId, cancellationToken);
+    }
+
+    public async Task<bool> RemoveNodeAsync(string nodeId, CancellationToken cancellationToken = default)
+    {
+        // Get node to check for S3 file
+        var node = await _store.GetNodeAsync(SessionId, nodeId, cancellationToken);
+        if (node == null) return false;
+
+        // Delete S3 file if exists (stored as .zip)
+        if (!string.IsNullOrWhiteSpace(node.ResourceUri))
+        {
+            var folderName = node.ResourceFolderPath != null
+                ? Path.GetFileName(node.ResourceFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+                : nodeId;
+            var zipFileName = folderName + ".zip";
+            try
+            {
+                await _fileStorage.DeleteAsync(SessionId, zipFileName, cancellationToken);
+            }
+            catch
+            {
+                // Ignore S3 delete failures - node deletion should still proceed
+            }
+        }
+
+        await _store.RemoveEdgesForNodeAsync(SessionId, nodeId, cancellationToken);
+        return await _store.RemoveNodeAsync(SessionId, nodeId, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Factory for creating session-scoped knowledge graph clients.
+/// </summary>
+internal sealed class KnowledgeGraphClientFactory : IKnowledgeGraphClientFactory
+{
+    private readonly IKnowledgeGraphStore _store;
+    private readonly IFileStorage _fileStorage;
+
+    public KnowledgeGraphClientFactory(IKnowledgeGraphStore store, IFileStorage fileStorage)
+    {
+        _store = store;
+        _fileStorage = fileStorage;
+    }
+
+    public IKnowledgeGraphClient CreateClient(string sessionId)
+    {
+        return new KnowledgeGraphClient(sessionId, _store, _fileStorage);
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeChain.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeChain.cs
@@ -1,0 +1,44 @@
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// Result of explaining a knowledge node's dependencies.
+/// Contains the complete chain of knowledge leading to the target node.
+/// </summary>
+public sealed class KnowledgeChain
+{
+    /// <summary>Session this chain belongs to.</summary>
+    public string SessionId { get; init; } = "";
+
+    /// <summary>The target node being explained.</summary>
+    public required KnowledgeNode TargetNode { get; init; }
+
+    /// <summary>
+    /// All nodes in the dependency chain, ordered by level.
+    /// Level 0 is the target node, Level 1 is direct dependencies, etc.
+    /// </summary>
+    public IReadOnlyList<KnowledgeChainLevel> Levels { get; init; } = [];
+
+    /// <summary>
+    /// Flattened list of all unique nodes in the chain (for convenience).
+    /// Ordered from target to root dependencies.
+    /// </summary>
+    public IReadOnlyList<KnowledgeNode> Chain { get; init; } = [];
+
+    /// <summary>Total number of nodes in the chain.</summary>
+    public int TotalNodes => Chain.Count;
+
+    /// <summary>Maximum depth of the dependency chain.</summary>
+    public int MaxDepth => Levels.Count > 0 ? Levels.Count - 1 : 0;
+}
+
+/// <summary>
+/// A level in the knowledge dependency chain (BFS layer).
+/// </summary>
+public sealed class KnowledgeChainLevel
+{
+    /// <summary>Depth level (0 = target node, 1 = direct deps, etc.)</summary>
+    public int Depth { get; init; }
+
+    /// <summary>Nodes at this depth level.</summary>
+    public IReadOnlyList<KnowledgeNode> Nodes { get; init; } = [];
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeChainDetails.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeChainDetails.cs
@@ -1,0 +1,20 @@
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// Result of getting knowledge chain details, containing both the structured chain
+/// and a human-readable text description in Markdown format.
+/// </summary>
+public sealed class KnowledgeChainDetails
+{
+    /// <summary>
+    /// The structured knowledge chain with nodes organized by inference levels.
+    /// </summary>
+    public required KnowledgeChain Chain { get; init; }
+
+    /// <summary>
+    /// A human-readable Markdown description of the knowledge chain,
+    /// formatted as a mini research paper with abstract, derivation path,
+    /// and detailed node information.
+    /// </summary>
+    public required string Description { get; init; }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeEdge.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeEdge.cs
@@ -1,0 +1,16 @@
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// A directed edge in the knowledge graph (from -> to means "from depends on to").
+/// </summary>
+public sealed class KnowledgeEdge
+{
+    /// <summary>Source node ID (the dependent).</summary>
+    public required string FromId { get; init; }
+
+    /// <summary>Target node ID (the dependency).</summary>
+    public required string ToId { get; init; }
+
+    /// <summary>When this edge was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeNode.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeNode.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// A knowledge node in the graph representing a piece of scientific knowledge.
+/// </summary>
+public sealed class KnowledgeNode
+{
+    /// <summary>Unique identifier within the session (provided by caller).</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Session ID for isolation between different sessions.</summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>Type of knowledge this node represents.</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required KnowledgeNodeType NodeType { get; init; }
+
+    /// <summary>Core description - a concise summary of the key conclusion.</summary>
+    public required string CoreDescription { get; init; }
+
+    /// <summary>Detailed description - comprehensive explanation of this knowledge.</summary>
+    public required string DetailedDescription { get; init; }
+
+    /// <summary>Optional proof in Markdown format.</summary>
+    public string? Proof { get; init; }
+
+    /// <summary>Original local folder path for resources (before zip & upload).</summary>
+    public string? ResourceFolderPath { get; init; }
+
+    /// <summary>S3 presigned HTTPS URL for resource download.</summary>
+    public string? ResourceUri { get; init; }
+
+    /// <summary>When this node was created.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>IDs of nodes this node depends on (upstream dependencies).</summary>
+    public IReadOnlyList<string> DependsOn { get; init; } = [];
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeNodeType.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeNodeType.cs
@@ -1,0 +1,72 @@
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// Predefined knowledge node types for categorizing knowledge in the graph.
+/// </summary>
+public enum KnowledgeNodeType
+{
+    /// <summary>Generic knowledge node.</summary>
+    Generic = 0,
+
+    // ===== Mathematics =====
+    /// <summary>A mathematical axiom - a fundamental assumption.</summary>
+    MathAxiom = 100,
+    /// <summary>A mathematical theorem - a proven statement.</summary>
+    MathTheorem = 101,
+    /// <summary>A mathematical proof.</summary>
+    MathProof = 102,
+    /// <summary>A mathematical definition.</summary>
+    MathDefinition = 103,
+    /// <summary>A mathematical lemma - a helper theorem.</summary>
+    MathLemma = 104,
+    /// <summary>A mathematical corollary - a direct consequence of a theorem.</summary>
+    MathCorollary = 105,
+
+    // ===== Physics =====
+    /// <summary>A physics law.</summary>
+    PhysicsLaw = 200,
+    /// <summary>A physics theory.</summary>
+    PhysicsTheory = 201,
+    /// <summary>A physics experiment result.</summary>
+    PhysicsExperiment = 202,
+
+    // ===== Biology =====
+    /// <summary>A biology experiment result.</summary>
+    BiologyExperiment = 300,
+    /// <summary>A biological process description.</summary>
+    BiologyProcess = 301,
+    /// <summary>A biological structure description.</summary>
+    BiologyStructure = 302,
+
+    // ===== Chemistry =====
+    /// <summary>A chemistry experiment result.</summary>
+    ChemistryExperiment = 400,
+    /// <summary>A chemical reaction description.</summary>
+    ChemistryReaction = 401,
+
+    // ===== Computer Science =====
+    /// <summary>An algorithm description.</summary>
+    CsAlgorithm = 500,
+    /// <summary>A data structure description.</summary>
+    CsDataStructure = 501,
+    /// <summary>A software design pattern.</summary>
+    CsDesignPattern = 502,
+
+    // ===== General Research =====
+    /// <summary>A research paper or publication.</summary>
+    ResearchPaper = 600,
+    /// <summary>A research dataset.</summary>
+    ResearchDataset = 601,
+    /// <summary>Research analysis results.</summary>
+    ResearchAnalysis = 602,
+    /// <summary>A research hypothesis.</summary>
+    ResearchHypothesis = 603,
+
+    // ===== Documentation =====
+    /// <summary>A note or annotation.</summary>
+    Note = 700,
+    /// <summary>A summary or abstract.</summary>
+    Summary = 701,
+    /// <summary>A reference to external content.</summary>
+    Reference = 702
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeSnapshot.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Models/KnowledgeSnapshot.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.Agents.Knowledge.Graph.Models;
+
+/// <summary>
+/// Complete snapshot of a knowledge graph for a session.
+/// </summary>
+public sealed class KnowledgeSnapshot
+{
+    /// <summary>Session this snapshot belongs to.</summary>
+    public string SessionId { get; init; } = "";
+
+    /// <summary>All nodes in the graph.</summary>
+    public IReadOnlyList<KnowledgeNode> Nodes { get; init; } = [];
+
+    /// <summary>All edges in the graph.</summary>
+    public IReadOnlyList<KnowledgeEdge> Edges { get; init; } = [];
+
+    /// <summary>Total number of nodes.</summary>
+    public int NodeCount => Nodes.Count;
+
+    /// <summary>Total number of edges.</summary>
+    public int EdgeCount => Edges.Count;
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/README.md
+++ b/src/Aevatar.Agents.Knowledge.Graph/README.md
@@ -1,0 +1,283 @@
+# Aevatar.Agents.Knowledge.Graph
+
+A session-scoped knowledge graph library designed for scientific research assistants. It enables building, querying, and exporting interconnected knowledge as structured inference chains and research papers.
+
+## Purpose
+
+This library provides a directed acyclic graph (DAG) structure for managing scientific knowledge with:
+
+- **Knowledge Nodes**: Represent pieces of scientific knowledge (axioms, theorems, experiments, definitions, etc.)
+- **Inference Edges**: Connect nodes via dependency relationships (A depends on B means A is derived from B)
+- **Session Isolation**: Each session maintains its own isolated knowledge graph
+- **Paper Generation**: Automatically generate mini research papers from knowledge chains
+
+Typical use cases:
+- AI research assistants that need to track reasoning chains
+- Scientific knowledge management systems
+- Educational tools that explain derivation of concepts
+- Any application requiring traceable knowledge dependencies
+
+## Design Philosophy
+
+### 1. Session-Scoped Isolation
+
+Each knowledge graph client operates within a session scope. This enables:
+- Multi-tenant scenarios where different users/sessions have independent graphs
+- Clean separation of knowledge contexts
+- Safe concurrent access patterns
+
+```csharp
+var factory = serviceProvider.GetRequiredService<IKnowledgeGraphClientFactory>();
+var client = factory.CreateClient("session-123"); // All operations scoped to this session
+```
+
+### 2. DAG Structure for Valid Inference Chains
+
+Knowledge graphs must remain acyclic to maintain valid logical inference chains:
+- A node can depend on multiple existing nodes (multiple premises)
+- Circular dependencies are automatically detected and rejected
+- This ensures all knowledge can be traced back to foundational axioms
+
+### 3. Pluggable Storage Backend
+
+The library uses `IGraphClient` from `Aevatar.Agents.Persistence.Graph` as its storage backend:
+- **In-Memory**: Fast, ephemeral storage for testing or transient sessions
+- **Neo4j**: Persistent graph database for production use
+
+### 4. Optional Resource Storage
+
+Knowledge nodes can have associated files (datasets, proofs, figures):
+- Files are automatically zipped and uploaded to S3-compatible storage
+- Presigned URLs are generated for secure download access
+- Falls back to local file paths when S3 is not configured
+
+## Architecture
+
+```
+Aevatar.Agents.Knowledge.Graph/
+├── IKnowledgeGraphClient.cs       # Main public API interface
+├── KnowledgeGraphClient.cs        # Implementation + Factory
+├── Models/
+│   ├── KnowledgeNode.cs           # Node data model
+│   ├── KnowledgeEdge.cs           # Edge data model
+│   ├── KnowledgeNodeType.cs       # Node type enumeration
+│   ├── KnowledgeSnapshot.cs           # Complete graph state
+│   ├── KnowledgeChain.cs          # Inference chain structure
+│   └── KnowledgeChainDetails.cs   # Chain + Markdown description
+├── Exceptions/
+│   ├── NodeNotFoundException.cs   # Node doesn't exist
+│   ├── DuplicateNodeException.cs  # Node ID already exists
+│   └── CycleDetectedException.cs  # Would create a cycle
+├── Storage/
+│   ├── IFileStorage.cs            # File storage abstraction
+│   ├── NullFileStorage.cs         # No-op implementation
+│   └── S3FileStorage.cs           # S3-compatible storage
+├── Store/
+│   ├── IKnowledgeGraphStore.cs    # Internal storage interface
+│   └── GraphClientBackedStore.cs  # IGraphClient implementation
+├── Validation/
+│   └── DagValidator.cs            # Cycle detection
+└── DependencyInjection/
+    └── ServiceCollectionExtensions.cs  # DI registration
+```
+
+## Installation
+
+Add a reference to the project:
+
+```xml
+<ProjectReference Include="path/to/Aevatar.Agents.Knowledge.Graph.csproj" />
+```
+
+## Usage Examples
+
+### Basic Setup with Dependency Injection
+
+```csharp
+// Program.cs or Startup.cs
+services.AddAevatarGraphInMemory();  // Or AddAevatarGraphNeo4j(...)
+services.AddKnowledgeGraph();
+```
+
+### Creating a Session-Scoped Client
+
+```csharp
+var factory = serviceProvider.GetRequiredService<IKnowledgeGraphClientFactory>();
+var client = factory.CreateClient("research-session-001");
+```
+
+### Adding Knowledge Nodes
+
+```csharp
+// Add a foundational axiom (no dependencies)
+var axiom = await client.AddNodeAsync(
+    nodeId: "empty-set",
+    nodeType: KnowledgeNodeType.MathAxiom,
+    coreDescription: "The empty set exists",
+    detailedDescription: "There exists a set with no elements, denoted as {} or ∅.");
+
+// Add a definition that depends on the axiom
+var definition = await client.AddNodeAsync(
+    nodeId: "natural-zero",
+    nodeType: KnowledgeNodeType.MathDefinition,
+    coreDescription: "Zero is defined as the empty set",
+    detailedDescription: "In von Neumann ordinals, 0 := ∅.",
+    dependsOn: ["empty-set"]);
+
+// Add a theorem with proof and resource files
+var theorem = await client.AddNodeAsync(
+    nodeId: "successor-function",
+    nodeType: KnowledgeNodeType.MathTheorem,
+    coreDescription: "The successor function is well-defined",
+    detailedDescription: "For any natural number n, S(n) = n ∪ {n} is also a natural number.",
+    proof: "By induction on n...",
+    resourceFolderPath: "/path/to/proof-diagrams",  // Will be zipped and uploaded to S3
+    dependsOn: ["natural-zero"]);
+```
+
+### Getting Knowledge Chain Details
+
+```csharp
+// Get the full derivation chain and description for a node
+var details = await client.GetKnowledgeChainDetailsAsync("successor-function");
+
+// Access the structured chain
+var chain = details.Chain;
+Console.WriteLine($"Target: {chain.TargetNode.CoreDescription}");
+Console.WriteLine($"Chain depth: {chain.MaxDepth}");
+Console.WriteLine($"Total nodes: {chain.TotalNodes}");
+
+// Iterate through levels (Level 0 = target, Level N = foundations)
+foreach (var level in chain.Levels)
+{
+    Console.WriteLine($"Level {level.Depth}:");
+    foreach (var node in level.Nodes)
+    {
+        Console.WriteLine($"  - {node.CoreDescription}");
+    }
+}
+
+// Access the Markdown description (mini research paper)
+string markdownDescription = details.Description;
+// Contains:
+// - Title and abstract
+// - Derivation path from foundations to target
+// - Full details of each node (ID, Type, CoreDescription, DetailedDescription, Proof, ResourceUri)
+// - References section
+```
+
+### Generating Full Research Paper
+
+```csharp
+// Generate a comprehensive paper from entire graph
+string fullPaper = await client.GenerateFullPaperAsync();
+// Returns Markdown with all nodes organized by type and inference relationships
+```
+
+### Working with Graph Snapshots
+
+```csharp
+// Get complete graph state
+var snapshot = await client.GetKnowledgeSnapshotAsync();
+
+Console.WriteLine($"Session: {snapshot.SessionId}");
+Console.WriteLine($"Nodes: {snapshot.NodeCount}");
+Console.WriteLine($"Edges: {snapshot.EdgeCount}");
+
+// Access all nodes and edges
+foreach (var node in snapshot.Nodes)
+{
+    Console.WriteLine($"{node.Id}: {node.CoreDescription}");
+}
+```
+
+### Removing Nodes
+
+```csharp
+// Removes the node and all connected edges
+// Also deletes associated S3 files
+bool removed = await client.RemoveNodeAsync("successor-function");
+```
+
+### S3 Storage Configuration
+
+```csharp
+services.AddAevatarGraphNeo4j(options =>
+{
+    options.Uri = "bolt://localhost:7687";
+    options.User = "neo4j";
+    options.Password = "password";
+});
+
+services.AddKnowledgeGraph(options =>
+{
+    // MinIO (local development)
+    options.Endpoint = "localhost:9000";
+    options.AccessKey = "minioadmin";
+    options.SecretKey = "minioadmin";
+    options.BucketName = "knowledge-graph";
+    options.UseSsl = false;
+
+    // AWS S3
+    // options.Endpoint = "s3.us-east-1.amazonaws.com";
+    // options.Region = "us-east-1";
+    // options.AccessKey = "AKIA...";
+    // options.SecretKey = "...";
+    // options.BucketName = "my-knowledge-bucket";
+    // options.UseSsl = true;
+});
+```
+
+## Knowledge Node Types
+
+The library provides predefined node types for various scientific domains:
+
+| Category | Types |
+|----------|-------|
+| Mathematics | `MathAxiom`, `MathTheorem`, `MathProof`, `MathDefinition`, `MathLemma`, `MathCorollary` |
+| Physics | `PhysicsLaw`, `PhysicsTheory`, `PhysicsExperiment` |
+| Biology | `BiologyExperiment`, `BiologyProcess`, `BiologyStructure` |
+| Chemistry | `ChemistryExperiment`, `ChemistryReaction` |
+| Computer Science | `CsAlgorithm`, `CsDataStructure`, `CsDesignPattern` |
+| Research | `ResearchPaper`, `ResearchDataset`, `ResearchAnalysis`, `ResearchHypothesis` |
+| Documentation | `Note`, `Summary`, `Reference` |
+
+## Exception Handling
+
+```csharp
+try
+{
+    await client.AddNodeAsync("theorem-1", KnowledgeNodeType.MathTheorem,
+        "A theorem", "Details...",
+        dependsOn: ["non-existent-axiom"]);
+}
+catch (NodeNotFoundException ex)
+{
+    Console.WriteLine($"Dependency not found: {ex.NodeId}");
+}
+catch (DuplicateNodeException ex)
+{
+    Console.WriteLine($"Node already exists: {ex.NodeId}");
+}
+catch (CycleDetectedException ex)
+{
+    Console.WriteLine($"Would create cycle: {ex.FromNodeId} -> {ex.ToNodeId}");
+}
+```
+
+## Thread Safety
+
+- `IKnowledgeGraphClient` instances are designed for single-session use
+- The underlying `IGraphClient` implementations handle their own thread safety
+- For concurrent access to the same session, consider using appropriate synchronization
+
+## Dependencies
+
+- `Aevatar.Agents.Persistence.Graph` - Graph storage abstraction (IGraphClient)
+- `Microsoft.Extensions.DependencyInjection.Abstractions` - DI support
+- `Microsoft.Extensions.Options` - Options pattern
+- `Minio` - S3-compatible storage client (optional)
+
+## License
+
+See the root project license.

--- a/src/Aevatar.Agents.Knowledge.Graph/Storage/IFileStorage.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Storage/IFileStorage.cs
@@ -1,0 +1,66 @@
+namespace Aevatar.Agents.Knowledge.Graph.Storage;
+
+/// <summary>
+/// Abstraction for file storage (S3, local filesystem, etc.).
+/// Files are organized by session: {rootBucket}/{sessionId}/{filename}
+/// </summary>
+public interface IFileStorage
+{
+    /// <summary>
+    /// Uploads a local folder to storage as a zip archive.
+    /// The folder is compressed and uploaded as {folderName}.zip.
+    /// </summary>
+    /// <param name="sessionId">Session ID for bucket isolation.</param>
+    /// <param name="localFolderPath">Path to the local folder to upload.</param>
+    /// <param name="remoteFileName">Optional remote filename (without .zip extension). If null, uses folder name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The storage URI (e.g., s3://bucket/session/folder.zip).</returns>
+    Task<string> UploadFolderAsync(
+        string sessionId,
+        string localFolderPath,
+        string? remoteFileName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads a zip archive from storage and extracts to a local folder.
+    /// </summary>
+    /// <param name="sessionId">Session ID.</param>
+    /// <param name="remoteFileName">Remote filename (the .zip file).</param>
+    /// <param name="localFolderPath">Local folder path to extract to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DownloadFolderAsync(
+        string sessionId,
+        string remoteFileName,
+        string localFolderPath,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a file exists in storage.
+    /// </summary>
+    Task<bool> ExistsAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a file from storage.
+    /// </summary>
+    Task DeleteAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a presigned URL for direct download (valid for limited time).
+    /// </summary>
+    /// <param name="sessionId">Session ID.</param>
+    /// <param name="remoteFileName">Remote filename.</param>
+    /// <param name="expiresIn">Expiration time.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Presigned URL.</returns>
+    Task<string> GetPresignedUrlAsync(
+        string sessionId,
+        string remoteFileName,
+        TimeSpan expiresIn,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Storage/NullFileStorage.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Storage/NullFileStorage.cs
@@ -1,0 +1,56 @@
+namespace Aevatar.Agents.Knowledge.Graph.Storage;
+
+/// <summary>
+/// No-op file storage for when S3 is not configured.
+/// Folder paths are stored as-is without uploading.
+/// </summary>
+public sealed class NullFileStorage : IFileStorage
+{
+    public Task<string> UploadFolderAsync(
+        string sessionId,
+        string localFolderPath,
+        string? remoteFileName = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Return the local path as-is (no upload)
+        return Task.FromResult(localFolderPath);
+    }
+
+    public Task DownloadFolderAsync(
+        string sessionId,
+        string remoteFileName,
+        string localFolderPath,
+        CancellationToken cancellationToken = default)
+    {
+        // No-op
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default)
+    {
+        // Check local folder
+        return Task.FromResult(Directory.Exists(remoteFileName));
+    }
+
+    public Task DeleteAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default)
+    {
+        // No-op
+        return Task.CompletedTask;
+    }
+
+    public Task<string> GetPresignedUrlAsync(
+        string sessionId,
+        string remoteFileName,
+        TimeSpan expiresIn,
+        CancellationToken cancellationToken = default)
+    {
+        // Return file:// URI
+        return Task.FromResult($"file://{remoteFileName}");
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Storage/S3FileStorage.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Storage/S3FileStorage.cs
@@ -1,0 +1,246 @@
+using System.IO.Compression;
+using Minio;
+using Minio.DataModel.Args;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Agents.Knowledge.Graph.Storage;
+
+/// <summary>
+/// S3-compatible file storage using Minio client.
+/// Folders are zipped and stored as: {rootBucket}/{sessionId}/{folderName}.zip
+/// </summary>
+public sealed class S3FileStorage : IFileStorage
+{
+    private readonly IMinioClient _client;
+    private readonly S3StorageOptions _options;
+    private readonly ILogger<S3FileStorage> _logger;
+
+    public S3FileStorage(
+        IMinioClient client,
+        IOptions<S3StorageOptions> options,
+        ILogger<S3FileStorage> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<string> UploadFolderAsync(
+        string sessionId,
+        string localFolderPath,
+        string? remoteFileName = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localFolderPath);
+
+        if (!Directory.Exists(localFolderPath))
+        {
+            throw new DirectoryNotFoundException($"Local folder not found: {localFolderPath}");
+        }
+
+        // Determine the zip filename
+        var folderName = Path.GetFileName(localFolderPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var zipFileName = (remoteFileName ?? folderName) + ".zip";
+        var objectName = $"{sessionId}/{zipFileName}";
+
+        // Create temp zip file
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
+        try
+        {
+            // Zip the folder
+            _logger.LogDebug("Compressing folder {FolderPath} to {ZipPath}", localFolderPath, tempZipPath);
+            ZipFile.CreateFromDirectory(localFolderPath, tempZipPath, CompressionLevel.Optimal, includeBaseDirectory: false);
+
+            await EnsureBucketExistsAsync(cancellationToken);
+
+            // Upload the zip file
+            await _client.PutObjectAsync(new PutObjectArgs()
+                .WithBucket(_options.BucketName)
+                .WithObject(objectName)
+                .WithFileName(tempZipPath)
+                .WithContentType("application/zip"),
+                cancellationToken);
+
+            // Generate presigned HTTPS URL (valid for 7 days - max for S3)
+            var presignedUrl = await _client.PresignedGetObjectAsync(new PresignedGetObjectArgs()
+                .WithBucket(_options.BucketName)
+                .WithObject(objectName)
+                .WithExpiry((int)TimeSpan.FromDays(7).TotalSeconds));
+
+            _logger.LogDebug("Uploaded folder {FolderPath}, presigned URL: {Url}", localFolderPath, presignedUrl);
+
+            return presignedUrl;
+        }
+        finally
+        {
+            // Clean up temp file
+            if (File.Exists(tempZipPath))
+            {
+                try { File.Delete(tempZipPath); }
+                catch { /* ignore cleanup errors */ }
+            }
+        }
+    }
+
+    public async Task DownloadFolderAsync(
+        string sessionId,
+        string remoteFileName,
+        string localFolderPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(localFolderPath);
+
+        var objectName = $"{sessionId}/{remoteFileName}";
+
+        // Create temp file for download
+        var tempZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
+        try
+        {
+            // Download the zip file
+            await _client.GetObjectAsync(new GetObjectArgs()
+                .WithBucket(_options.BucketName)
+                .WithObject(objectName)
+                .WithFile(tempZipPath),
+                cancellationToken);
+
+            // Ensure target directory exists
+            if (!Directory.Exists(localFolderPath))
+            {
+                Directory.CreateDirectory(localFolderPath);
+            }
+
+            // Extract the zip file
+            _logger.LogDebug("Extracting {ZipPath} to {FolderPath}", tempZipPath, localFolderPath);
+            ZipFile.ExtractToDirectory(tempZipPath, localFolderPath, overwriteFiles: true);
+
+            _logger.LogDebug("Downloaded and extracted {ObjectName} to {FolderPath}", objectName, localFolderPath);
+        }
+        finally
+        {
+            // Clean up temp file
+            if (File.Exists(tempZipPath))
+            {
+                try { File.Delete(tempZipPath); }
+                catch { /* ignore cleanup errors */ }
+            }
+        }
+    }
+
+    public async Task<bool> ExistsAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteFileName);
+
+        var objectName = $"{sessionId}/{remoteFileName}";
+
+        try
+        {
+            await _client.StatObjectAsync(new StatObjectArgs()
+                .WithBucket(_options.BucketName)
+                .WithObject(objectName),
+                cancellationToken);
+            return true;
+        }
+        catch (Minio.Exceptions.ObjectNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    public async Task DeleteAsync(
+        string sessionId,
+        string remoteFileName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteFileName);
+
+        var objectName = $"{sessionId}/{remoteFileName}";
+
+        await _client.RemoveObjectAsync(new RemoveObjectArgs()
+            .WithBucket(_options.BucketName)
+            .WithObject(objectName),
+            cancellationToken);
+
+        _logger.LogDebug("Deleted {ObjectName}", objectName);
+    }
+
+    public async Task<string> GetPresignedUrlAsync(
+        string sessionId,
+        string remoteFileName,
+        TimeSpan expiresIn,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteFileName);
+
+        var objectName = $"{sessionId}/{remoteFileName}";
+
+        var url = await _client.PresignedGetObjectAsync(new PresignedGetObjectArgs()
+            .WithBucket(_options.BucketName)
+            .WithObject(objectName)
+            .WithExpiry((int)expiresIn.TotalSeconds));
+
+        return url;
+    }
+
+    private async Task EnsureBucketExistsAsync(CancellationToken cancellationToken)
+    {
+        var exists = await _client.BucketExistsAsync(
+            new BucketExistsArgs().WithBucket(_options.BucketName),
+            cancellationToken);
+
+        if (!exists)
+        {
+            await _client.MakeBucketAsync(
+                new MakeBucketArgs().WithBucket(_options.BucketName),
+                cancellationToken);
+            _logger.LogInformation("Created bucket: {BucketName}", _options.BucketName);
+        }
+    }
+}
+
+/// <summary>
+/// Options for S3 storage configuration.
+/// </summary>
+public sealed class S3StorageOptions
+{
+    /// <summary>
+    /// S3 endpoint URL (e.g., "localhost:9000" for Minio, "s3.amazonaws.com" for AWS).
+    /// For AWS, you can use the regional endpoint like "s3.us-east-1.amazonaws.com".
+    /// </summary>
+    public string Endpoint { get; set; } = "localhost:9000";
+
+    /// <summary>
+    /// AWS region (e.g., "us-east-1", "ap-southeast-1"). Required for AWS S3.
+    /// Leave null or empty for non-AWS S3-compatible services like MinIO.
+    /// </summary>
+    public string? Region { get; set; }
+
+    /// <summary>
+    /// Access key / username.
+    /// </summary>
+    public string AccessKey { get; set; } = "";
+
+    /// <summary>
+    /// Secret key / password.
+    /// </summary>
+    public string SecretKey { get; set; } = "";
+
+    /// <summary>
+    /// Root bucket name for knowledge graph files.
+    /// </summary>
+    public string BucketName { get; set; } = "knowledge-graph";
+
+    /// <summary>
+    /// Use SSL/TLS. Should be true for AWS S3.
+    /// </summary>
+    public bool UseSsl { get; set; } = false;
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Store/GraphClientBackedStore.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Store/GraphClientBackedStore.cs
@@ -1,0 +1,297 @@
+using Aevatar.Agents.Knowledge.Graph.Models;
+using Aevatar.Agents.Persistence.Graph.Abstractions;
+using Aevatar.Agents.Persistence.Graph.Core.Semantic;
+
+namespace Aevatar.Agents.Knowledge.Graph.Store;
+
+/// <summary>
+/// Implementation of IKnowledgeGraphStore backed by IGraphClient.
+/// This enables using Neo4j, InMemory, or any other IGraphClient backend.
+/// Session isolation is achieved by using composite IDs: {sessionId}:{nodeId}
+/// </summary>
+internal sealed class GraphClientBackedStore : IKnowledgeGraphStore
+{
+    private const string EdgeType = "DEPENDS_ON";
+    private const string PropSessionId = "sessionId";
+    private const string PropNodeId = "nodeId";
+    private const string PropNodeType = "nodeType";
+    private const string PropCoreDescription = "coreDescription";
+    private const string PropDetailedDescription = "detailedDescription";
+    private const string PropProof = "proof";
+    private const string PropResourceUri = "resourceUri";
+    private const string PropTimestamp = "timestamp";
+    private const string PropDependsOn = "dependsOn";
+    private const string PropCreatedAt = "createdAt";
+
+    private readonly IGraphClient _graphClient;
+
+    public GraphClientBackedStore(IGraphClient graphClient)
+    {
+        _graphClient = graphClient;
+    }
+
+    /// <summary>
+    /// Creates a composite key for storage: {sessionId}:{nodeId}
+    /// </summary>
+    private static string CompositeId(string sessionId, string nodeId) => $"{sessionId}:{nodeId}";
+
+    /// <summary>
+    /// Gets the node type string to use in IGraphClient.
+    /// Using the KnowledgeNodeType enum name as the graph node type.
+    /// </summary>
+    private static string GetNodeTypeString(KnowledgeNodeType nodeType) => nodeType.ToString();
+
+    public async Task AddNodeAsync(KnowledgeNode node, CancellationToken cancellationToken)
+    {
+        var compositeId = CompositeId(node.SessionId, node.Id);
+        var nodeTypeStr = GetNodeTypeString(node.NodeType);
+
+        var properties = new Dictionary<string, Value>
+        {
+            ["id"] = new StringValue(compositeId),
+            [PropSessionId] = new StringValue(node.SessionId),
+            [PropNodeId] = new StringValue(node.Id),
+            [PropNodeType] = new StringValue(nodeTypeStr),
+            [PropCoreDescription] = new StringValue(node.CoreDescription),
+            [PropDetailedDescription] = new StringValue(node.DetailedDescription),
+            [PropTimestamp] = new StringValue(node.Timestamp.ToString("O")),
+            [PropDependsOn] = new StringValue(string.Join(",", node.DependsOn))
+        };
+
+        if (node.Proof != null)
+        {
+            properties[PropProof] = new StringValue(node.Proof);
+        }
+
+        // Only store the HTTPS URL, not the local folder path
+        if (node.ResourceUri != null)
+        {
+            properties[PropResourceUri] = new StringValue(node.ResourceUri);
+        }
+
+        await _graphClient.WriteAsync(nodeTypeStr, properties);
+    }
+
+    public async Task<KnowledgeNode?> GetNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken)
+    {
+        var compositeId = CompositeId(sessionId, nodeId);
+        var graphNode = await _graphClient.ReadAsync(new NodeId(compositeId));
+        return graphNode == null ? null : ToKnowledgeNode(graphNode);
+    }
+
+    public async Task<IReadOnlyList<KnowledgeNode>> GetAllNodesAsync(string sessionId, CancellationToken cancellationToken)
+    {
+        // Query all node types and filter by session
+        var allNodes = new List<KnowledgeNode>();
+
+        foreach (var nodeType in Enum.GetValues<KnowledgeNodeType>())
+        {
+            var nodeTypeStr = GetNodeTypeString(nodeType);
+            var nodes = await _graphClient.QueryAsync(new NodeQuery { Type = nodeTypeStr });
+
+            foreach (var node in nodes)
+            {
+                if (node.Properties.TryGetValue(PropSessionId, out var sessionVal) &&
+                    sessionVal is StringValue sv && sv.Data == sessionId)
+                {
+                    allNodes.Add(ToKnowledgeNode(node));
+                }
+            }
+        }
+
+        return allNodes;
+    }
+
+    public async Task<bool> RemoveNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken)
+    {
+        var compositeId = CompositeId(sessionId, nodeId);
+        var exists = await NodeExistsAsync(sessionId, nodeId, cancellationToken);
+        if (!exists) return false;
+
+        await _graphClient.DeleteAsync(new NodeId(compositeId));
+        return true;
+    }
+
+    public async Task<bool> NodeExistsAsync(string sessionId, string nodeId, CancellationToken cancellationToken)
+    {
+        var compositeId = CompositeId(sessionId, nodeId);
+        var node = await _graphClient.ReadAsync(new NodeId(compositeId));
+        return node != null;
+    }
+
+    private const string PropFromNodeId = "fromNodeId";
+    private const string PropToNodeId = "toNodeId";
+
+    public async Task AddEdgeAsync(KnowledgeEdge edge, string sessionId, CancellationToken cancellationToken)
+    {
+        var fromCompositeId = CompositeId(sessionId, edge.FromId);
+        var toCompositeId = CompositeId(sessionId, edge.ToId);
+
+        var properties = new Dictionary<string, Value>
+        {
+            [PropSessionId] = new StringValue(sessionId),
+            [PropCreatedAt] = new StringValue(edge.CreatedAt.ToString("O")),
+            // Store business node IDs directly in edge properties for reliable retrieval
+            [PropFromNodeId] = new StringValue(edge.FromId),
+            [PropToNodeId] = new StringValue(edge.ToId)
+        };
+
+        await _graphClient.WriteAsync(
+            EdgeType,
+            new NodeId(fromCompositeId),
+            new NodeId(toCompositeId),
+            properties);
+    }
+
+    public async Task<IReadOnlyList<KnowledgeEdge>> GetAllEdgesAsync(string sessionId, CancellationToken cancellationToken)
+    {
+        var edges = await _graphClient.QueryAsync(new EdgeQuery { Type = EdgeType });
+
+        return edges
+            .Where(e => e.Properties.TryGetValue(PropSessionId, out var sv) &&
+                        sv is StringValue sessionVal && sessionVal.Data == sessionId)
+            .Select(e =>
+            {
+                var createdAt = DateTimeOffset.UtcNow;
+                if (e.Properties.TryGetValue(PropCreatedAt, out var createdAtVal) && createdAtVal is StringValue sv)
+                {
+                    createdAt = DateTimeOffset.Parse(sv.Data);
+                }
+
+                // Read node IDs directly from edge properties (stored when edge was created)
+                // Fall back to parsing From/To values for backwards compatibility
+                string fromId, toId;
+
+                if (e.Properties.TryGetValue(PropFromNodeId, out var fromVal) && fromVal is StringValue fromStr)
+                {
+                    fromId = fromStr.Data;
+                }
+                else
+                {
+                    var fromParts = e.From.Value.Split(':', 2);
+                    fromId = fromParts.Length > 1 ? fromParts[1] : e.From.Value;
+                }
+
+                if (e.Properties.TryGetValue(PropToNodeId, out var toVal) && toVal is StringValue toStr)
+                {
+                    toId = toStr.Data;
+                }
+                else
+                {
+                    var toParts = e.To.Value.Split(':', 2);
+                    toId = toParts.Length > 1 ? toParts[1] : e.To.Value;
+                }
+
+                return new KnowledgeEdge
+                {
+                    FromId = fromId,
+                    ToId = toId,
+                    CreatedAt = createdAt
+                };
+            })
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<string>> GetDependenciesAsync(string sessionId, string nodeId, CancellationToken cancellationToken)
+    {
+        var allEdges = await _graphClient.QueryAsync(new EdgeQuery { Type = EdgeType });
+
+        // Edge direction: node -[DEPENDS_ON]-> dependency (From: node, To: dependency)
+        // Read node IDs from edge properties
+        return allEdges
+            .Where(e => e.Properties.TryGetValue(PropSessionId, out var sv) &&
+                        sv is StringValue sessionVal && sessionVal.Data == sessionId &&
+                        e.Properties.TryGetValue(PropFromNodeId, out var fromVal) &&
+                        fromVal is StringValue fromStr && fromStr.Data == nodeId)
+            .Select(e =>
+            {
+                if (e.Properties.TryGetValue(PropToNodeId, out var toVal) && toVal is StringValue toStr)
+                {
+                    return toStr.Data;
+                }
+                var toParts = e.To.Value.Split(':', 2);
+                return toParts.Length > 1 ? toParts[1] : e.To.Value;
+            })
+            .ToList();
+    }
+
+    public async Task RemoveEdgesForNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken)
+    {
+        var allEdges = await _graphClient.QueryAsync(new EdgeQuery { Type = EdgeType });
+
+        // Find edges where this node is either the source or target
+        var edgesToRemove = allEdges
+            .Where(e => e.Properties.TryGetValue(PropSessionId, out var sv) &&
+                        sv is StringValue sessionVal && sessionVal.Data == sessionId &&
+                        ((e.Properties.TryGetValue(PropFromNodeId, out var fromVal) &&
+                          fromVal is StringValue fromStr && fromStr.Data == nodeId) ||
+                         (e.Properties.TryGetValue(PropToNodeId, out var toVal) &&
+                          toVal is StringValue toStr && toStr.Data == nodeId)))
+            .ToList();
+
+        foreach (var edge in edgesToRemove)
+        {
+            await _graphClient.DeleteAsync(edge.Id);
+        }
+    }
+
+    private static KnowledgeNode ToKnowledgeNode(GraphNode graphNode)
+    {
+        var props = graphNode.Properties;
+
+        var sessionId = props.TryGetValue(PropSessionId, out var sessionVal) && sessionVal is StringValue sessionSv
+            ? sessionSv.Data
+            : "";
+
+        var nodeId = props.TryGetValue(PropNodeId, out var nodeIdVal) && nodeIdVal is StringValue nodeIdSv
+            ? nodeIdSv.Data
+            : graphNode.Id.Value;
+
+        var nodeTypeStr = props.TryGetValue(PropNodeType, out var nodeTypeVal) && nodeTypeVal is StringValue nodeTypeSv
+            ? nodeTypeSv.Data
+            : "Generic";
+        var nodeType = Enum.TryParse<KnowledgeNodeType>(nodeTypeStr, out var nt) ? nt : KnowledgeNodeType.Generic;
+
+        var coreDescription = props.TryGetValue(PropCoreDescription, out var coreVal) && coreVal is StringValue coreSv
+            ? coreSv.Data
+            : "";
+
+        var detailedDescription = props.TryGetValue(PropDetailedDescription, out var detailVal) && detailVal is StringValue detailSv
+            ? detailSv.Data
+            : "";
+
+        var proof = props.TryGetValue(PropProof, out var proofVal) && proofVal is StringValue proofSv
+            ? proofSv.Data
+            : null;
+
+        // ResourceFolderPath is not stored in Neo4j, only the HTTPS URL is stored
+        var resourceUri = props.TryGetValue(PropResourceUri, out var uriVal) && uriVal is StringValue uriSv
+            ? uriSv.Data
+            : null;
+
+        var timestamp = props.TryGetValue(PropTimestamp, out var timestampVal) && timestampVal is StringValue timestampSv
+            ? DateTimeOffset.Parse(timestampSv.Data)
+            : DateTimeOffset.UtcNow;
+
+        var dependsOnStr = props.TryGetValue(PropDependsOn, out var depsVal) && depsVal is StringValue depsSv
+            ? depsSv.Data
+            : "";
+        var dependsOn = string.IsNullOrEmpty(dependsOnStr)
+            ? Array.Empty<string>()
+            : dependsOnStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        return new KnowledgeNode
+        {
+            Id = nodeId,
+            SessionId = sessionId,
+            NodeType = nodeType,
+            CoreDescription = coreDescription,
+            DetailedDescription = detailedDescription,
+            Proof = proof,
+            ResourceFolderPath = null, // Not stored in Neo4j
+            ResourceUri = resourceUri,
+            Timestamp = timestamp,
+            DependsOn = dependsOn
+        };
+    }
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Store/IKnowledgeGraphStore.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Store/IKnowledgeGraphStore.cs
@@ -1,0 +1,21 @@
+using Aevatar.Agents.Knowledge.Graph.Models;
+
+namespace Aevatar.Agents.Knowledge.Graph.Store;
+
+/// <summary>
+/// Internal interface for knowledge graph storage.
+/// All operations are scoped to a session ID for isolation.
+/// </summary>
+internal interface IKnowledgeGraphStore
+{
+    Task AddNodeAsync(KnowledgeNode node, CancellationToken cancellationToken);
+    Task<KnowledgeNode?> GetNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<KnowledgeNode>> GetAllNodesAsync(string sessionId, CancellationToken cancellationToken);
+    Task<bool> RemoveNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken);
+    Task<bool> NodeExistsAsync(string sessionId, string nodeId, CancellationToken cancellationToken);
+
+    Task AddEdgeAsync(KnowledgeEdge edge, string sessionId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<KnowledgeEdge>> GetAllEdgesAsync(string sessionId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<string>> GetDependenciesAsync(string sessionId, string nodeId, CancellationToken cancellationToken);
+    Task RemoveEdgesForNodeAsync(string sessionId, string nodeId, CancellationToken cancellationToken);
+}

--- a/src/Aevatar.Agents.Knowledge.Graph/Validation/DagValidator.cs
+++ b/src/Aevatar.Agents.Knowledge.Graph/Validation/DagValidator.cs
@@ -1,0 +1,76 @@
+using Aevatar.Agents.Knowledge.Graph.Store;
+
+namespace Aevatar.Agents.Knowledge.Graph.Validation;
+
+/// <summary>
+/// Validates that the knowledge graph maintains DAG (Directed Acyclic Graph) properties.
+/// </summary>
+internal sealed class DagValidator
+{
+    private readonly IKnowledgeGraphStore _store;
+
+    public DagValidator(IKnowledgeGraphStore store)
+    {
+        _store = store;
+    }
+
+    /// <summary>
+    /// Checks if a node exists in the graph.
+    /// </summary>
+    public Task<bool> NodeExistsAsync(string sessionId, string nodeId, CancellationToken cancellationToken = default)
+    {
+        return _store.NodeExistsAsync(sessionId, nodeId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Validates that adding the specified dependencies would not create a cycle.
+    /// Uses BFS to check if any dependency can reach the new node.
+    /// </summary>
+    public async Task<bool> ValidateNoCycleAsync(
+        string sessionId,
+        string newNodeId,
+        IEnumerable<string> dependsOnIds,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var depId in dependsOnIds)
+        {
+            if (await CanReachAsync(sessionId, depId, newNodeId, cancellationToken))
+            {
+                return false; // Would create cycle
+            }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// BFS to check if fromId can reach toId through dependency edges.
+    /// </summary>
+    private async Task<bool> CanReachAsync(
+        string sessionId,
+        string fromId,
+        string toId,
+        CancellationToken cancellationToken)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<string>();
+        queue.Enqueue(fromId);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (string.Equals(current, toId, StringComparison.Ordinal)) return true;
+            if (!visited.Add(current)) continue;
+
+            var deps = await _store.GetDependenciesAsync(sessionId, current, cancellationToken);
+            foreach (var dep in deps)
+            {
+                if (!visited.Contains(dep))
+                {
+                    queue.Enqueue(dep);
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Aevatar.Agents.Knowledge.Graph.Tests/Aevatar.Agents.Knowledge.Graph.Tests.csproj
+++ b/test/Aevatar.Agents.Knowledge.Graph.Tests/Aevatar.Agents.Knowledge.Graph.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.Agents.Knowledge.Graph\Aevatar.Agents.Knowledge.Graph.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Agents.Persistence.InMemory.Graph\Aevatar.Agents.Persistence.InMemory.Graph.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Aevatar.Agents.Knowledge.Graph.Tests/KnowledgeGraphClientTests.cs
+++ b/test/Aevatar.Agents.Knowledge.Graph.Tests/KnowledgeGraphClientTests.cs
@@ -1,0 +1,604 @@
+using Aevatar.Agents.Knowledge.Graph;
+using Aevatar.Agents.Knowledge.Graph.Exceptions;
+using Aevatar.Agents.Knowledge.Graph.Models;
+using Aevatar.Agents.Persistence.InMemory.Graph;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Aevatar.Agents.Knowledge.Graph.Tests;
+
+public class KnowledgeGraphClientTests
+{
+    private readonly IKnowledgeGraphClientFactory _factory;
+
+    public KnowledgeGraphClientTests()
+    {
+        var services = new ServiceCollection();
+        services.AddAevatarGraphInMemory();
+        services.AddKnowledgeGraph();
+        _factory = services.BuildServiceProvider().GetRequiredService<IKnowledgeGraphClientFactory>();
+    }
+
+    private IKnowledgeGraphClient CreateClient(string? sessionId = null)
+    {
+        return _factory.CreateClient(sessionId ?? Guid.NewGuid().ToString("N"));
+    }
+
+    #region AddNodeAsync Tests
+
+    [Fact]
+    public async Task AddNodeAsync_SimpleNode_CreatesSuccessfully()
+    {
+        var client = CreateClient();
+
+        var node = await client.AddNodeAsync(
+            "axiom-1",
+            KnowledgeNodeType.MathAxiom,
+            "The base case axiom for natural numbers",
+            "Zero is defined as the first natural number. This is a foundational axiom in Peano arithmetic.");
+
+        node.ShouldNotBeNull();
+        node.Id.ShouldBe("axiom-1");
+        node.NodeType.ShouldBe(KnowledgeNodeType.MathAxiom);
+        node.CoreDescription.ShouldBe("The base case axiom for natural numbers");
+        node.DetailedDescription.ShouldBe("Zero is defined as the first natural number. This is a foundational axiom in Peano arithmetic.");
+        node.SessionId.ShouldBe(client.SessionId);
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_WithOptionalFields_StoresAllFields()
+    {
+        var client = CreateClient();
+
+        var node = await client.AddNodeAsync(
+            "theorem-1",
+            KnowledgeNodeType.MathTheorem,
+            "Pythagorean theorem",
+            "In a right triangle, the square of the hypotenuse equals the sum of squares of the other two sides.",
+            proof: "Let a, b be the legs and c be the hypotenuse. By area comparison of squares...");
+
+        node.DetailedDescription.ShouldBe("In a right triangle, the square of the hypotenuse equals the sum of squares of the other two sides.");
+        node.Proof.ShouldBe("Let a, b be the legs and c be the hypotenuse. By area comparison of squares...");
+
+        // Verify retrieval from store
+        var retrieved = await client.GetNodeAsync("theorem-1");
+        retrieved.ShouldNotBeNull();
+        retrieved.DetailedDescription.ShouldBe(node.DetailedDescription);
+        retrieved.Proof.ShouldBe(node.Proof);
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_WithDependencies_CreatesEdges()
+    {
+        var client = CreateClient();
+
+        var axiom = await client.AddNodeAsync("axiom-1", KnowledgeNodeType.MathAxiom, "Base axiom", "Detailed base axiom description");
+        var theorem = await client.AddNodeAsync(
+            "theorem-1",
+            KnowledgeNodeType.MathTheorem,
+            "Derived theorem",
+            "This theorem is derived from the base axiom",
+            dependsOn: [axiom.Id]);
+
+        theorem.DependsOn.ShouldContain(axiom.Id);
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+        snapshot.EdgeCount.ShouldBe(1);
+        // Edge direction: node -[DEPENDS_ON]-> dependency (theorem depends on axiom)
+        snapshot.Edges[0].FromId.ShouldBe(theorem.Id);
+        snapshot.Edges[0].ToId.ShouldBe(axiom.Id);
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_NonExistentDependency_ThrowsNodeNotFoundException()
+    {
+        var client = CreateClient();
+
+        var ex = await Should.ThrowAsync<NodeNotFoundException>(
+            () => client.AddNodeAsync("theorem-1", KnowledgeNodeType.MathTheorem, "Theorem", "Detailed theorem", dependsOn: ["nonexistent"])
+        );
+        ex.NodeId.ShouldBe("nonexistent");
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_DuplicateId_ThrowsDuplicateNodeException()
+    {
+        var client = CreateClient();
+
+        await client.AddNodeAsync("axiom-1", KnowledgeNodeType.MathAxiom, "First axiom", "First axiom details");
+
+        var ex = await Should.ThrowAsync<DuplicateNodeException>(
+            () => client.AddNodeAsync("axiom-1", KnowledgeNodeType.MathAxiom, "Duplicate axiom", "Duplicate details")
+        );
+        ex.NodeId.ShouldBe("axiom-1");
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_MultipleDependencies_CreatesAllEdges()
+    {
+        var client = CreateClient();
+
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom A", "Detailed A");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathAxiom, "Axiom B", "Detailed B");
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathAxiom, "Axiom C", "Detailed C");
+        var theorem = await client.AddNodeAsync("theorem", KnowledgeNodeType.MathTheorem, "Combined theorem",
+            "Depends on A, B, and C", dependsOn: [a.Id, b.Id, c.Id]);
+
+        theorem.DependsOn.Count.ShouldBe(3);
+        theorem.DependsOn.ShouldContain(a.Id);
+        theorem.DependsOn.ShouldContain(b.Id);
+        theorem.DependsOn.ShouldContain(c.Id);
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+        snapshot.EdgeCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_ValidDiamondDependency_DoesNotThrow()
+    {
+        var client = CreateClient();
+
+        // Diamond dependency is valid (not a cycle):
+        // A <- B <- C, and D depends on both C and A
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom A", "Detailed A");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem B", "Detailed B", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Corollary C", "Detailed C", dependsOn: [b.Id]);
+
+        // This should NOT throw - D depends on C and A, which is a valid DAG (diamond shape)
+        var d = await client.AddNodeAsync("d", KnowledgeNodeType.MathTheorem, "Theorem D", "Valid diamond",
+            dependsOn: [c.Id, a.Id]);
+
+        d.ShouldNotBeNull();
+        d.DependsOn.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_SelfDependency_ThrowsNodeNotFoundException()
+    {
+        var client = CreateClient();
+
+        // Node depending on itself - but since node doesn't exist yet,
+        // it throws NodeNotFoundException (dependency validation happens first)
+        await Should.ThrowAsync<NodeNotFoundException>(
+            () => client.AddNodeAsync("self-ref", KnowledgeNodeType.Note, "Self reference", "Depends on itself",
+                dependsOn: ["self-ref"])
+        );
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_WithResourceFolderPath_NonExistentFolder_CreatesNodeWithoutResource()
+    {
+        var client = CreateClient();
+
+        // Non-existent folder should not throw, just skip resource upload
+        var node = await client.AddNodeAsync("node-with-missing-resource", KnowledgeNodeType.Note,
+            "Node with missing resource", "Detailed description",
+            resourceFolderPath: "/nonexistent/folder/path");
+
+        node.ShouldNotBeNull();
+        node.ResourceUri.ShouldBeNull(); // No resource uploaded
+    }
+
+    #endregion
+
+    #region GetNodeAsync Tests
+
+    [Fact]
+    public async Task GetNodeAsync_ExistingNode_ReturnsNode()
+    {
+        var client = CreateClient();
+
+        var created = await client.AddNodeAsync("axiom-1", KnowledgeNodeType.MathAxiom, "Test axiom", "Test axiom details");
+        var fetched = await client.GetNodeAsync(created.Id);
+
+        fetched.ShouldNotBeNull();
+        fetched!.Id.ShouldBe(created.Id);
+        fetched.NodeType.ShouldBe(KnowledgeNodeType.MathAxiom);
+    }
+
+    [Fact]
+    public async Task GetNodeAsync_NonExistent_ReturnsNull()
+    {
+        var client = CreateClient();
+
+        var result = await client.GetNodeAsync("nonexistent");
+        result.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region Session Isolation Tests
+
+    [Fact]
+    public async Task Sessions_AreIsolated()
+    {
+        var client1 = CreateClient("session-1");
+        var client2 = CreateClient("session-2");
+
+        await client1.AddNodeAsync("shared-id", KnowledgeNodeType.MathAxiom, "Session 1 axiom", "Session 1 details");
+        await client2.AddNodeAsync("shared-id", KnowledgeNodeType.BiologyExperiment, "Session 2 experiment", "Session 2 details");
+
+        var node1 = await client1.GetNodeAsync("shared-id");
+        var node2 = await client2.GetNodeAsync("shared-id");
+
+        node1.ShouldNotBeNull();
+        node2.ShouldNotBeNull();
+        node1!.NodeType.ShouldBe(KnowledgeNodeType.MathAxiom);
+        node2!.NodeType.ShouldBe(KnowledgeNodeType.BiologyExperiment);
+    }
+
+    [Fact]
+    public async Task GetKnowledgeSnapshotAsync_OnlyReturnsCurrentSessionNodes()
+    {
+        var client1 = CreateClient("session-1");
+        var client2 = CreateClient("session-2");
+
+        await client1.AddNodeAsync("node-1", KnowledgeNodeType.MathAxiom, "Session 1 node", "Session 1 details");
+        await client2.AddNodeAsync("node-2", KnowledgeNodeType.BiologyExperiment, "Session 2 node", "Session 2 details");
+        await client2.AddNodeAsync("node-3", KnowledgeNodeType.BiologyExperiment, "Session 2 another node", "Session 2 another details");
+
+        var snapshot1 = await client1.GetKnowledgeSnapshotAsync();
+        var snapshot2 = await client2.GetKnowledgeSnapshotAsync();
+
+        snapshot1.NodeCount.ShouldBe(1);
+        snapshot2.NodeCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region GetKnowledgeSnapshotAsync Tests
+
+    [Fact]
+    public async Task GetKnowledgeSnapshotAsync_ReturnsAllNodesAndEdges()
+    {
+        var client = CreateClient();
+
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom A", "Detailed Axiom A");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem B", "Detailed Theorem B", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Corollary C", "Detailed Corollary C", dependsOn: [b.Id]);
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+
+        snapshot.NodeCount.ShouldBe(3);
+        snapshot.EdgeCount.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region GetKnowledgeChainDetailsAsync Tests
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_SimpleChain_ReturnsCompleteChainAndDescription()
+    {
+        var client = CreateClient();
+
+        // A <- B <- C (C depends on B, B depends on A)
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom", "Detailed Axiom");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem", "Detailed Theorem", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Corollary", "Detailed Corollary", dependsOn: [b.Id]);
+
+        var details = await client.GetKnowledgeChainDetailsAsync(c.Id);
+
+        // Verify chain structure
+        details.Chain.TargetNode.Id.ShouldBe(c.Id);
+        details.Chain.TotalNodes.ShouldBe(3);
+        details.Chain.MaxDepth.ShouldBe(2);
+        details.Chain.Levels.Count.ShouldBe(3);
+
+        details.Chain.Levels[0].Nodes[0].Id.ShouldBe("c");
+        details.Chain.Levels[1].Nodes[0].Id.ShouldBe("b");
+        details.Chain.Levels[2].Nodes[0].Id.ShouldBe("a");
+
+        // Verify description is generated
+        details.Description.ShouldNotBeNullOrWhiteSpace();
+        details.Description.ShouldContain("Corollary");
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_DiamondDependency_HandlesCorrectly()
+    {
+        var client = CreateClient();
+
+        // D <- B, D <- C, B <- A, C <- A (diamond pattern)
+        var d = await client.AddNodeAsync("d", KnowledgeNodeType.MathAxiom, "Root axiom", "Detailed root axiom");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathLemma, "Lemma B", "Detailed Lemma B", dependsOn: [d.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathLemma, "Lemma C", "Detailed Lemma C", dependsOn: [d.Id]);
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathTheorem, "Theorem A", "Detailed Theorem A", dependsOn: [b.Id, c.Id]);
+
+        var details = await client.GetKnowledgeChainDetailsAsync(a.Id);
+
+        details.Chain.TotalNodes.ShouldBe(4); // D only counted once
+        details.Chain.Chain.Select(n => n.Id).Distinct().Count().ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_NodeWithNoDependencies_ReturnsSingleLevel()
+    {
+        var client = CreateClient();
+
+        var node = await client.AddNodeAsync("standalone", KnowledgeNodeType.Note, "Standalone note", "Detailed standalone note");
+
+        var details = await client.GetKnowledgeChainDetailsAsync(node.Id);
+
+        details.Chain.TotalNodes.ShouldBe(1);
+        details.Chain.MaxDepth.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_NonExistentNode_ThrowsNodeNotFoundException()
+    {
+        var client = CreateClient();
+
+        await Should.ThrowAsync<NodeNotFoundException>(
+            () => client.GetKnowledgeChainDetailsAsync("nonexistent")
+        );
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_ReturnsMarkdownDescription()
+    {
+        var client = CreateClient();
+
+        // A <- B <- C (C depends on B, B depends on A)
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Base axiom", "This is the foundational axiom.");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Main theorem", "This theorem builds on the base axiom.",
+            proof: "By applying the base axiom, we can derive...", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Final corollary", "This corollary follows from the main theorem.", dependsOn: [b.Id]);
+
+        var details = await client.GetKnowledgeChainDetailsAsync(c.Id);
+
+        // Verify description contains expected markdown content
+        var description = details.Description;
+        description.ShouldNotBeNullOrWhiteSpace();
+        description.ShouldContain("# Final corollary"); // Title from CoreDescription
+        description.ShouldContain("## Abstract"); // Abstract section
+        description.ShouldContain("## Table of Contents");
+        description.ShouldContain("## Knowledge Nodes");
+        description.ShouldContain("Main theorem"); // CoreDescription in chain
+        description.ShouldContain("Base axiom"); // CoreDescription in chain
+        description.ShouldContain("MathAxiom");
+        description.ShouldContain("MathTheorem");
+        description.ShouldContain("MathCorollary");
+        description.ShouldContain("By applying the base axiom"); // Proof content
+        // Verify DetailedDescription IS in description
+        description.ShouldContain("This is the foundational axiom");
+        description.ShouldContain("This theorem builds on the base axiom");
+        description.ShouldContain("This corollary follows from the main theorem");
+        // Verify derivation path
+        description.ShouldContain("Derivation Path");
+        description.ShouldContain("Foundation");
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_WithResourceUri_IncludesResourceLink()
+    {
+        var client = CreateClient();
+
+        // Create node with a mock resource URI (simulating S3 upload result)
+        var node = await client.AddNodeAsync("node-with-resource", KnowledgeNodeType.ResearchPaper,
+            "Research Paper", "A paper with attached resources");
+
+        // Note: We can't easily test actual S3 upload without mocking, but we can verify
+        // the description generation handles nodes correctly
+        var details = await client.GetKnowledgeChainDetailsAsync(node.Id);
+
+        details.Description.ShouldContain("Research Paper");
+        details.Description.ShouldContain("## Abstract");
+        details.Chain.TargetNode.Id.ShouldBe("node-with-resource");
+    }
+
+    #endregion
+
+    #region GenerateFullPaperAsync Tests
+
+    [Fact]
+    public async Task GenerateFullPaperAsync_ReturnsComprehensivePaper()
+    {
+        var client = CreateClient();
+
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom A", "Detailed Axiom A");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem B", "Detailed Theorem B", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Corollary C", "Detailed Corollary C", dependsOn: [b.Id]);
+
+        var paper = await client.GenerateFullPaperAsync();
+
+        paper.ShouldNotBeNullOrWhiteSpace();
+        paper.ShouldContain("# Knowledge Graph Research Paper");
+        paper.ShouldContain("## Abstract");
+        paper.ShouldContain("## Knowledge Overview");
+        paper.ShouldContain("## Detailed Knowledge");
+        paper.ShouldContain("Axiom A");
+        paper.ShouldContain("Theorem B");
+        paper.ShouldContain("Corollary C");
+        paper.ShouldContain("Total Knowledge Nodes**: 3");
+    }
+
+    [Fact]
+    public async Task GenerateFullPaperAsync_EmptyGraph_ReturnsEmptyPaper()
+    {
+        var client = CreateClient();
+
+        var paper = await client.GenerateFullPaperAsync();
+
+        paper.ShouldNotBeNullOrWhiteSpace();
+        paper.ShouldContain("# Knowledge Graph Research Paper");
+        paper.ShouldContain("Total Knowledge Nodes**: 0");
+    }
+
+    #endregion
+
+    #region RemoveNodeAsync Tests
+
+    [Fact]
+    public async Task RemoveNodeAsync_ExistingNode_RemovesSuccessfully()
+    {
+        var client = CreateClient();
+
+        var node = await client.AddNodeAsync("to-delete", KnowledgeNodeType.Note, "Will be deleted", "Detailed content to delete");
+
+        var result = await client.RemoveNodeAsync(node.Id);
+
+        result.ShouldBeTrue();
+        (await client.GetNodeAsync(node.Id)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RemoveNodeAsync_NonExistent_ReturnsFalse()
+    {
+        var client = CreateClient();
+
+        var result = await client.RemoveNodeAsync("nonexistent");
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RemoveNodeAsync_RemovesConnectedEdges()
+    {
+        var client = CreateClient();
+
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom", "Detailed Axiom");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem", "Detailed Theorem", dependsOn: [a.Id]);
+
+        await client.RemoveNodeAsync(a.Id);
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+        snapshot.EdgeCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RemoveNodeAsync_MiddleNode_RemovesBothIncomingAndOutgoingEdges()
+    {
+        var client = CreateClient();
+
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Axiom", "Detailed Axiom");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathTheorem, "Theorem", "Detailed Theorem", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathCorollary, "Corollary", "Detailed Corollary", dependsOn: [b.Id]);
+
+        // Remove middle node B
+        await client.RemoveNodeAsync(b.Id);
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+        snapshot.NodeCount.ShouldBe(2); // A and C remain
+        snapshot.EdgeCount.ShouldBe(0); // All edges involving B are removed
+    }
+
+    #endregion
+
+    #region Complex Graph Structure Tests
+
+    [Fact]
+    public async Task ComplexDAG_MultiplePathsToRoot_HandlesCorrectly()
+    {
+        var client = CreateClient();
+
+        // Create a complex DAG:
+        //       A
+        //      / \
+        //     B   C
+        //      \ / \
+        //       D   E
+        //        \ /
+        //         F
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Root Axiom", "Root");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathLemma, "Lemma B", "Lemma B", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathLemma, "Lemma C", "Lemma C", dependsOn: [a.Id]);
+        var d = await client.AddNodeAsync("d", KnowledgeNodeType.MathTheorem, "Theorem D", "Theorem D", dependsOn: [b.Id, c.Id]);
+        var e = await client.AddNodeAsync("e", KnowledgeNodeType.MathTheorem, "Theorem E", "Theorem E", dependsOn: [c.Id]);
+        var f = await client.AddNodeAsync("f", KnowledgeNodeType.MathCorollary, "Corollary F", "Corollary F", dependsOn: [d.Id, e.Id]);
+
+        var details = await client.GetKnowledgeChainDetailsAsync(f.Id);
+
+        // F depends on all nodes (A, B, C, D, E, F)
+        details.Chain.TotalNodes.ShouldBe(6);
+        details.Chain.Chain.Select(n => n.Id).Distinct().Count().ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task GetKnowledgeChainDetailsAsync_DeepChain_ReturnsCorrectDepth()
+    {
+        var client = CreateClient();
+
+        // Create a deep chain: A <- B <- C <- D <- E (depth 4)
+        var a = await client.AddNodeAsync("a", KnowledgeNodeType.MathAxiom, "Level 0", "Root");
+        var b = await client.AddNodeAsync("b", KnowledgeNodeType.MathLemma, "Level 1", "L1", dependsOn: [a.Id]);
+        var c = await client.AddNodeAsync("c", KnowledgeNodeType.MathLemma, "Level 2", "L2", dependsOn: [b.Id]);
+        var d = await client.AddNodeAsync("d", KnowledgeNodeType.MathTheorem, "Level 3", "L3", dependsOn: [c.Id]);
+        var e = await client.AddNodeAsync("e", KnowledgeNodeType.MathCorollary, "Level 4", "L4", dependsOn: [d.Id]);
+
+        var details = await client.GetKnowledgeChainDetailsAsync(e.Id);
+
+        details.Chain.MaxDepth.ShouldBe(4);
+        details.Chain.Levels.Count.ShouldBe(5); // 5 levels (0-4)
+    }
+
+    #endregion
+
+    #region Factory Tests
+
+    [Fact]
+    public void Factory_CreateClient_ReturnsClientWithCorrectSessionId()
+    {
+        var client = _factory.CreateClient("test-session-123");
+
+        client.SessionId.ShouldBe("test-session-123");
+    }
+
+    [Fact]
+    public void Factory_CreateMultipleClients_ReturnsIndependentClients()
+    {
+        var client1 = _factory.CreateClient("session-a");
+        var client2 = _factory.CreateClient("session-b");
+
+        client1.SessionId.ShouldNotBe(client2.SessionId);
+        client1.ShouldNotBeSameAs(client2);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public async Task GetKnowledgeSnapshotAsync_EmptyGraph_ReturnsEmptySnapshot()
+    {
+        var client = CreateClient();
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+
+        snapshot.NodeCount.ShouldBe(0);
+        snapshot.EdgeCount.ShouldBe(0);
+        snapshot.Nodes.ShouldBeEmpty();
+        snapshot.Edges.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task AddNodeAsync_AllNodeTypes_WorkCorrectly()
+    {
+        var client = CreateClient();
+
+        // Test various node types
+        var nodes = new List<KnowledgeNode>
+        {
+            await client.AddNodeAsync("math-axiom", KnowledgeNodeType.MathAxiom, "Math Axiom", "Details"),
+            await client.AddNodeAsync("math-theorem", KnowledgeNodeType.MathTheorem, "Math Theorem", "Details"),
+            await client.AddNodeAsync("math-lemma", KnowledgeNodeType.MathLemma, "Math Lemma", "Details"),
+            await client.AddNodeAsync("math-corollary", KnowledgeNodeType.MathCorollary, "Math Corollary", "Details"),
+            await client.AddNodeAsync("physics-law", KnowledgeNodeType.PhysicsLaw, "Physics Law", "Details"),
+            await client.AddNodeAsync("biology-exp", KnowledgeNodeType.BiologyExperiment, "Biology Experiment", "Details"),
+            await client.AddNodeAsync("cs-algorithm", KnowledgeNodeType.CsAlgorithm, "CS Algorithm", "Details"),
+            await client.AddNodeAsync("note", KnowledgeNodeType.Note, "Note", "Details"),
+        };
+
+        var snapshot = await client.GetKnowledgeSnapshotAsync();
+        snapshot.NodeCount.ShouldBe(8);
+
+        foreach (var node in nodes)
+        {
+            var retrieved = await client.GetNodeAsync(node.Id);
+            retrieved.ShouldNotBeNull();
+            retrieved!.NodeType.ShouldBe(node.NodeType);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
DAG 能力强化
- 统一可调用API接口，服务于科研助手对Knowledge Graph的操作，如快捷添加节点等
- 一键生成知识节点推理链及其文本描述 （markdown），可feed给dag_builder agent用于dag -> 论文（只针对该知识链）
- 一键生成全图推理文本描述（markdown），可feed给dag_builder agent用于dag -> 论文（包含知识图谱中所有知识）
- 知识节点将不局限于短文本数据的存储，可以是任意类型文件，例如代码，实验数据，实验结果等，这些文件将被打包上传成知识图谱中该节点的一部分