### PR TITLE
feat(topology): enhance DAG node display with meaningful labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -541,3 +541,5 @@ scripts/.pids/
 .env.production
 
 deploy-frontend-s3.sh
+
+.playwright-mcp

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/workflow-topology/cyber-node.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/workflow-topology/cyber-node.tsx
@@ -7,6 +7,33 @@ import { Handle, Position } from '@xyflow/react'
 import { cn } from '@/lib/utils'
 import { NODE_STYLES, STATUS_OPACITY, type CyberNodeData } from './dag-node-styles'
 
+// ─── Extract meaningful core from node ID ───
+// "axiom_entropy_nonneg_v1" -> "entropy_nonneg"
+function extractIdCore(id: string): string {
+  const prefixes = [
+    // Full prefixes
+    'axiom_', 'theorem_', 'lemma_', 'plan_', 'knowledge_',
+    'analysis_', 'hypothesis_', 'verification_', 'final_',
+    'proof_', 'definition_', 'corollary_', 'proposition_',
+    // Short prefixes (thm_, ax_, etc.)
+    'thm_', 'ax_', 'lem_', 'def_', 'prop_', 'cor_',
+  ]
+  let core = id
+  for (const prefix of prefixes) {
+    if (core.startsWith(prefix)) {
+      core = core.slice(prefix.length)
+      break
+    }
+  }
+  // Remove version suffix (_v1, _v2, etc.)
+  core = core.replace(/_v\d+$/, '')
+  // Truncate if too long (max 10 chars for display)
+  if (core.length > 10) {
+    core = core.slice(0, 9) + '..'
+  }
+  return core
+}
+
 export function CyberNode({ data }: { data: CyberNodeData }) {
   const [showTooltip, setShowTooltip] = useState(false)
 
@@ -39,14 +66,14 @@ export function CyberNode({ data }: { data: CyberNodeData }) {
 
       <div
         className={cn(
-          "relative flex items-center justify-center rounded-full transition-all duration-300 hover:scale-110 cursor-pointer",
+          "relative flex items-center justify-center rounded-full transition-all duration-300 hover:scale-105 cursor-pointer",
           data.selected && "ring-2 ring-neon-gold ring-offset-2 ring-offset-bg-base",
           data.highlighted && !data.selected && "ring-2 ring-white/50 ring-offset-1 ring-offset-bg-base",
           isPulsing && "animate-glow-pulse"
         )}
         style={{
-          width: 48,
-          height: 48,
+          width: 72,
+          height: 72,
           background: `radial-gradient(circle, ${nodeStyle.bg} 0%, ${nodeStyle.border} 100%)`,
           border: `2px solid ${data.selected ? '#ffd700' : nodeStyle.border}`,
           boxShadow: data.selected
@@ -59,21 +86,28 @@ export function CyberNode({ data }: { data: CyberNodeData }) {
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
       >
-        {/* Kind indicator icon */}
-        {data.kind === 'Plan' && (
-          <span className="text-[10px]" style={{ color: '#0a0f19' }}>📋</span>
-        )}
-        {data.kind === 'Knowledge' && (
-          <span className="text-[10px]" style={{ color: '#0a0f19' }}>💡</span>
-        )}
-        {!data.kind && (
+        {/* ─── Inner Label: Kind + Short ID ─── */}
+        <div className="flex flex-col items-center justify-center gap-0.5 select-none">
+          {/* Kind row: emoji + type label */}
+          <div className="flex items-center gap-0.5">
+            <span className="text-xs leading-none">
+              {data.kind === 'Plan' ? '📋' : data.kind === 'Knowledge' ? '💡' : '⚡'}
+            </span>
+            <span
+              className="text-[9px] font-bold tracking-wide leading-none"
+              style={{ color: '#0a0f19', textShadow: '0 0 2px rgba(255,255,255,0.3)' }}
+            >
+              {isPulsing ? 'Active' : data.kind === 'Plan' ? 'Plan' : data.kind === 'Knowledge' ? 'Know' : 'Node'}
+            </span>
+          </div>
+          {/* ID row: extracted core content */}
           <span
-            className="font-mono font-extrabold text-[10px] tracking-wider"
-            style={{ color: '#0a0f19', textShadow: `0 0 2px ${nodeStyle.bg}` }}
+            className="text-[10px] font-mono leading-none"
+            style={{ color: '#0a0f19', opacity: 0.85 }}
           >
-            {data.id.slice(0, 4)}
+            {extractIdCore(data.id)}
           </span>
-        )}
+        </div>
       </div>
 
       {/* Hover Tooltip */}
@@ -83,32 +117,33 @@ export function CyberNode({ data }: { data: CyberNodeData }) {
           style={{ left: '50%', bottom: '100%', transform: 'translateX(-50%)', marginBottom: 10 }}
         >
           <div
-            className="px-4 py-3 rounded-lg text-xs font-mono whitespace-normal break-words"
+            className="px-3 py-2.5 rounded-lg text-xs font-mono"
             style={{
-              width: '280px',
+              minWidth: '180px',
+              maxWidth: '320px',
               background: 'rgba(10, 15, 25, 0.98)',
               border: `2px solid ${nodeStyle.border}`,
               boxShadow: `0 0 30px ${nodeStyle.glow}, 0 4px 20px rgba(0,0,0,0.5)`,
             }}
           >
-            <div className="flex items-center gap-2 mb-2 pb-2 border-b border-slate-600/50">
-              <span className="font-bold" style={{ color: nodeStyle.bg }}>{data.id}</span>
+            {/* Row 1: Badges */}
+            <div className="flex flex-wrap items-center gap-1.5 mb-2">
               {data.kind && (
                 <span className={cn(
-                  "text-[9px] px-1.5 py-0.5 rounded",
+                  "text-[9px] px-1.5 py-0.5 rounded shrink-0",
                   data.kind === 'Plan' ? "bg-blue-500/20 text-blue-400" : "bg-green-500/20 text-green-400"
                 )}>
                   {data.kind}
                 </span>
               )}
               {data.isOtherSession && (
-                <span className="text-[9px] px-1.5 py-0.5 rounded bg-gray-500/20 text-gray-400">
+                <span className="text-[9px] px-1.5 py-0.5 rounded bg-gray-500/20 text-gray-400 shrink-0">
                   Other Session
                 </span>
               )}
               {data.planStatus && (
                 <span className={cn(
-                  "text-[9px] px-1.5 py-0.5 rounded",
+                  "text-[9px] px-1.5 py-0.5 rounded shrink-0",
                   data.planStatus === 'Pending' && "bg-yellow-500/20 text-yellow-400",
                   data.planStatus === 'Active' && "bg-blue-500/20 text-blue-400",
                   data.planStatus === 'Completed' && "bg-green-500/20 text-green-400"
@@ -117,7 +152,21 @@ export function CyberNode({ data }: { data: CyberNodeData }) {
                 </span>
               )}
             </div>
-            <div className="text-slate-200 leading-relaxed text-[11px]">{data.label}</div>
+            {/* Row 2: ID (truncated) */}
+            <div
+              className="font-bold truncate mb-2 pb-2 border-b border-slate-600/50"
+              style={{ color: nodeStyle.bg }}
+              title={data.id}
+            >
+              {data.id.length > 24 ? data.id.slice(0, 22) + '..' : data.id}
+            </div>
+            {/* Row 3: Label (max 2 lines) */}
+            <div
+              className="text-slate-200 leading-relaxed text-[11px] line-clamp-2"
+              title={data.label}
+            >
+              {data.label}
+            </div>
           </div>
           <div
             className="absolute left-1/2 -translate-x-1/2"

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/workflow-topology/dag-layout.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/workflow-topology/dag-layout.ts
@@ -5,8 +5,8 @@
 import dagre from 'dagre'
 import { Position, type Node, type Edge } from '@xyflow/react'
 
-const NODE_WIDTH = 48
-const NODE_HEIGHT = 48
+const NODE_WIDTH = 72
+const NODE_HEIGHT = 72
 
 /**
  * Apply Dagre layout algorithm to position nodes in a DAG
@@ -21,7 +21,7 @@ export function getLayoutedElements(
 ): { nodes: Node[]; edges: Edge[] } {
   const dagreGraph = new dagre.graphlib.Graph()
   dagreGraph.setDefaultEdgeLabel(() => ({}))
-  dagreGraph.setGraph({ rankdir: direction, nodesep: 60, ranksep: 80 })
+  dagreGraph.setGraph({ rankdir: direction, nodesep: 70, ranksep: 90 })
 
   // Add nodes to dagre graph
   nodes.forEach((node) => {


### PR DESCRIPTION
- Add extractIdCore() to extract semantic content from node IDs (e.g., "axiom_entropy_nonneg_v1" -> "entropy_nonneg")
- Increase node size from 48px to 72px for better readability
- Display kind badge + short ID inside nodes
- Optimize tooltip layout with truncation and line clamping
- Adjust dagre layout spacing (nodesep: 70, ranksep: 90)
- Add .playwright-mcp to gitignore