### PR TITLE
feat(frontend): add 401 auto-refresh with retry and hide Platform Pro…

### DIFF
--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/App.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { listSessions, getDagSnapshot, getSessionEvents, parseWorkersFromEvents,
 import type { DAGGraph } from '@/types';
 import { cn } from '@/lib/utils';
 import { useAuthStore } from '@/store/auth-store';
+import { abpLogout } from '@/lib/abp/auth';
 
 // Panel collapse threshold (percentage)
 const COLLAPSE_THRESHOLD = 20;
@@ -80,9 +81,27 @@ const transformDagData = (rawData: unknown): DAGGraph | null => {
 
 const App: React.FC = () => {
   const { currentSessionId, isConnected, setSessions, setCurrentSession, resetForNewSession, setDag, updateWorker, restoreMilestoneForSession, setActiveMilestoneNodeId, restoreRunningSession } = useSisyphusStore();
+  const logout = useAuthStore((state) => state.logout);
   
   // New session dialog state
   const [showNewSessionDialog, setShowNewSessionDialog] = useState(false);
+
+  // === Global Auth Session Expiry Handler ===
+  // Listen for token refresh failures and force logout
+  useEffect(() => {
+    const handleSessionExpired = async () => {
+      console.warn('[App] Session expired - forcing logout');
+      await abpLogout();
+      logout();
+      // Navigate to login page
+      window.location.href = '/login';
+    };
+
+    window.addEventListener('auth:session-expired', handleSessionExpired);
+    return () => {
+      window.removeEventListener('auth:session-expired', handleSessionExpired);
+    };
+  }, [logout]);
 
   // Resizable panel state
   const [leftPanelWidth, setLeftPanelWidth] = useState(DEFAULT_LEFT_WIDTH);

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/settings/settings-panel.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/sisyphus/settings/settings-panel.tsx
@@ -36,7 +36,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ sessionId, connected }) =
       <nav className="flex-shrink-0 px-6 pt-4 flex gap-1 border-b border-border-subtle">
         {[
           { key: 'tools' as TabKey, label: 'Tools & MCP', icon: '⚙️' },
-          { key: 'providers' as TabKey, label: 'Platform Providers', icon: '🔑' },
+          // NOTE: Platform Providers tab hidden but code preserved
+          // { key: 'providers' as TabKey, label: 'Platform Providers', icon: '🔑' },
           { key: 'my-providers' as TabKey, label: 'My Providers', icon: '🔐' },
           { key: 'agents' as TabKey, label: 'Agents', icon: '🤖' },
           { key: 'advanced' as TabKey, label: 'Advanced', icon: '🛠️' },

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/axiom-client/fetch.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/axiom-client/fetch.ts
@@ -1,12 +1,18 @@
 // ============================================================================
 //  Axiom Client - Fetch Helper & Request Caching
+//  Supports 401 auto-refresh with retry
 // ============================================================================
 
 import { apiLogger } from '../logger'
-import { getAccessToken } from '../abp/config'
+import { getAccessToken, clearTokens } from '../abp/config'
+import { abpRefreshToken } from '../abp/auth'
 
 // === API Base URL ===
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
+
+// === Token Refresh State ===
+let isRefreshing = false
+let refreshPromise: Promise<boolean> | null = null
 
 // === Cache Types ===
 
@@ -54,6 +60,56 @@ export function clearRequestCache(): void {
 export interface FetchOptions {
   cache?: boolean
   cacheTtl?: number
+  skipAuthRefresh?: boolean // Skip 401 auto-refresh (for auth endpoints)
+}
+
+// === Core Fetch with 401 Auto-Refresh ===
+
+async function doFetch<T>(
+  path: string,
+  init: RequestInit | undefined,
+  abortController: AbortController
+): Promise<Response> {
+  const token = getAccessToken()
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    signal: abortController.signal,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...authHeaders,
+      ...init?.headers,
+    },
+  })
+}
+
+async function handleTokenRefresh(): Promise<boolean> {
+  // If already refreshing, wait for that to complete
+  if (isRefreshing && refreshPromise) {
+    return refreshPromise
+  }
+
+  isRefreshing = true
+  refreshPromise = abpRefreshToken()
+    .then((success) => {
+      if (!success) {
+        clearTokens()
+        // Dispatch event to notify app of auth failure
+        window.dispatchEvent(new CustomEvent('auth:session-expired'))
+      }
+      return success
+    })
+    .finally(() => {
+      isRefreshing = false
+      refreshPromise = null
+    })
+
+  return refreshPromise
 }
 
 export async function fetchJson<T>(
@@ -64,6 +120,7 @@ export async function fetchJson<T>(
   const cacheKey = `${init?.method || 'GET'}:${path}`
   const useCaching = options?.cache !== false && (!init?.method || init.method === 'GET')
   const ttl = options?.cacheTtl ?? CACHE_TTL_MS
+  const skipAuthRefresh = options?.skipAuthRefresh ?? false
 
   // Check cache first
   if (useCaching) {
@@ -87,26 +144,29 @@ export async function fetchJson<T>(
 
   const fetchPromise = (async () => {
     try {
-      const token = getAccessToken()
-      const authHeaders: Record<string, string> = token
-        ? { Authorization: `Bearer ${token}` }
-        : {}
+      let res = await doFetch<T>(path, init, abortController)
 
-      const res = await fetch(`${API_BASE}${path}`, {
-        ...init,
-        signal: abortController.signal,
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          ...authHeaders,
-          ...init?.headers,
-        },
-      })
+      // Handle 401: attempt token refresh and retry once
+      if (res.status === 401 && !skipAuthRefresh) {
+        apiLogger.info(`[fetchJson] 401 on ${path}, attempting token refresh...`)
+        
+        const refreshed = await handleTokenRefresh()
+        if (refreshed) {
+          apiLogger.info(`[fetchJson] Token refreshed, retrying ${path}...`)
+          // Retry with new token
+          res = await doFetch<T>(path, init, abortController)
+        } else {
+          apiLogger.warn(`[fetchJson] Token refresh failed for ${path}`)
+          const text = await res.text()
+          throw new Error(`API Error 401: ${text || 'Unauthorized - Session expired'}`)
+        }
+      }
+
       if (!res.ok) {
         const text = await res.text()
         throw new Error(`API Error ${res.status}: ${text}`)
       }
+
       const data = (await res.json()) as T
 
       if (useCaching) {


### PR DESCRIPTION
…viders tab

- Add token auto-refresh mechanism to fetchJson on 401 responses
- Implement singleton refresh lock to prevent concurrent refresh attempts
- Dispatch 'auth:session-expired' event when refresh fails
- Add global auth expiry handler in App.tsx to force logout and redirect
- Hide Platform Providers tab in settings panel (code preserved)