### PR TITLE
feat(oauth): replace Google GIS SDK with redirect flow and add backen…

### DIFF
--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/account/account-sidebar.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/account/account-sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { NavLink, useLocation } from "react-router-dom"
 import { User, Lock, Users, Shield, Key, Cpu } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { useHasPassword } from "@/store/auth-store"
 
 // ============================================================
 //  Account Sidebar - Navigation Menu (Basic Version)
@@ -12,12 +13,6 @@ interface NavItem {
   href: string
   icon: React.ReactNode
 }
-
-const settingsItems: NavItem[] = [
-  { label: "Profile", href: "/account/profile", icon: <User className="w-4 h-4" /> },
-  { label: "Password", href: "/account/password", icon: <Lock className="w-4 h-4" /> },
-  { label: "My Providers", href: "/account/providers", icon: <Cpu className="w-4 h-4" /> },
-]
 
 const adminItems: NavItem[] = [
   { label: "Users", href: "/admin/users", icon: <Users className="w-4 h-4" /> },
@@ -30,6 +25,16 @@ interface AccountSidebarProps {
 }
 
 export const AccountSidebar: React.FC<AccountSidebarProps> = ({ isAdmin }) => {
+  const hasPassword = useHasPassword()
+
+  // Build settings items dynamically — hide Password for OAuth users
+  const settingsItems: NavItem[] = [
+    { label: "Profile", href: "/account/profile", icon: <User className="w-4 h-4" /> },
+    ...(hasPassword
+      ? [{ label: "Password", href: "/account/password", icon: <Lock className="w-4 h-4" /> }]
+      : []),
+    { label: "My Providers", href: "/account/providers", icon: <Cpu className="w-4 h-4" /> },
+  ]
   const location = useLocation()
 
   const renderNavItem = (item: NavItem, isAdminSection = false) => {

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/account/panels/profile-panel.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/account/panels/profile-panel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import { Pencil, Lock, User, Camera, Save, X } from "lucide-react"
-import { useAuthStore } from "@/store/auth-store"
+import { useAuthStore, useHasPassword } from "@/store/auth-store"
 import { useNavigate } from "react-router-dom"
 import { AvatarUploadModal, AvatarCropModal } from "../avatar-modals"
 import { updateMyProfile, uploadProfilePicture, getProfilePictureUrl } from "@/lib/abp"
@@ -12,6 +12,7 @@ import { updateMyProfile, uploadProfilePicture, getProfilePictureUrl } from "@/l
 export const ProfilePanel: React.FC = () => {
   const { user, updateUser: updateAuthUser } = useAuthStore()
   const navigate = useNavigate()
+  const hasPassword = useHasPassword()
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false)
@@ -317,27 +318,30 @@ export const ProfilePanel: React.FC = () => {
       </div>
 
       {/* Security Settings Card */}
-      <div className="rounded-xl bg-surface border border-border-subtle p-6 space-y-4">
-        <h3 className="text-base font-semibold text-text-primary">Security Settings</h3>
+      {/* Security Settings — hide for OAuth users who have no password */}
+      {hasPassword && (
+        <div className="rounded-xl bg-surface border border-border-subtle p-6 space-y-4">
+          <h3 className="text-base font-semibold text-text-primary">Security Settings</h3>
 
-        {/* Password Row */}
-        <div className="flex items-center justify-between p-4 rounded-lg bg-surface-elevated">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-xl bg-neon-gold/10 flex items-center justify-center">
-                <Lock className="w-5 h-5 text-neon-gold" />
+          {/* Password Row */}
+          <div className="flex items-center justify-between p-4 rounded-lg bg-surface-elevated">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-neon-gold/10 flex items-center justify-center">
+                  <Lock className="w-5 h-5 text-neon-gold" />
+                </div>
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium text-text-primary">Password</p>
+                </div>
               </div>
-              <div className="space-y-0.5">
-                <p className="text-sm font-medium text-text-primary">Password</p>
-              </div>
-            </div>
-          <button
-            onClick={() => navigate("/account/password")}
-            className="px-3.5 py-2 text-xs font-medium text-bg-base bg-neon-gold rounded-md hover:bg-neon-gold/90 transition-colors"
-          >
-            Change
-          </button>
+            <button
+              onClick={() => navigate("/account/password")}
+              className="px-3.5 py-2 text-xs font-medium text-bg-base bg-neon-gold rounded-md hover:bg-neon-gold/90 transition-colors"
+            >
+              Change
+            </button>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Avatar Upload Modal */}
       <AvatarUploadModal

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/admin/admin-sidebar.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/admin/admin-sidebar.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { NavLink, useLocation } from "react-router-dom"
 import { User, Lock, Users, Shield, Key, Settings } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { useHasPassword } from "@/store/auth-store"
 
 // ============================================================
 //  Admin Sidebar - Navigation with Settings + Management
@@ -12,11 +13,6 @@ interface NavItem {
   href: string
   icon: React.ReactNode
 }
-
-const settingsItems: NavItem[] = [
-  { label: "Profile", href: "/account/profile", icon: <User className="w-4 h-4" /> },
-  { label: "Password", href: "/account/password", icon: <Lock className="w-4 h-4" /> },
-]
 
 const managementItems: NavItem[] = [
   { label: "Users", href: "/admin/users", icon: <Users className="w-4 h-4" /> },
@@ -32,6 +28,15 @@ const platformItem: NavItem = {
 
 export const AdminSidebar: React.FC = () => {
   const location = useLocation()
+  const hasPassword = useHasPassword()
+
+  // Build settings items dynamically — hide Password for OAuth users
+  const settingsItems: NavItem[] = [
+    { label: "Profile", href: "/account/profile", icon: <User className="w-4 h-4" /> },
+    ...(hasPassword
+      ? [{ label: "Password", href: "/account/password", icon: <Lock className="w-4 h-4" /> }]
+      : []),
+  ]
 
   const renderNavItem = (item: NavItem, useGold = false) => {
     const isActive = location.pathname === item.href

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/ui/user-menu.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/components/ui/user-menu.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu'
-import { useAuthStore, useIsAdmin } from '@/store/auth-store'
+import { useAuthStore, useIsAdmin, useHasPassword } from '@/store/auth-store'
 
 // ============================================================
 //  User Menu - Reusable Profile Dropdown
@@ -24,6 +24,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({ showName = true }) => {
   const navigate = useNavigate()
   const { user, isAuthenticated, logout } = useAuthStore()
   const isAdmin = useIsAdmin()
+  const hasPassword = useHasPassword()
 
   const handleLogout = () => {
     logout()
@@ -107,19 +108,25 @@ export const UserMenu: React.FC<UserMenuProps> = ({ showName = true }) => {
         >
           Profile
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => navigate('/account/password')}
-          icon={<Lock className="w-4 h-4" />}
-        >
-          Password
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onClick={() => navigate('/admin/settings')}
-          icon={<Settings className="w-4 h-4" />}
-        >
-          Platform Settings
-        </DropdownMenuItem>
+        {hasPassword && (
+          <DropdownMenuItem
+            onClick={() => navigate('/account/password')}
+            icon={<Lock className="w-4 h-4" />}
+          >
+            Password
+          </DropdownMenuItem>
+        )}
+        {isAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => navigate('/admin/settings')}
+              icon={<Settings className="w-4 h-4" />}
+            >
+              Platform Settings
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={handleLogout}

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/config.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/config.ts
@@ -1,12 +1,18 @@
 // ============================================================
 //  OAuth Configuration - Environment Variables
 // ============================================================
+//
+//  Both Google and GitHub use the redirect flow with backend
+//  token exchange for security and ABP Identity integration.
+//
+// ============================================================
 
 export const oauthConfig = {
   google: {
     clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID || '',
     redirectUri: `${window.location.origin}/auth/callback/google`,
     scope: 'openid email profile',
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
   },
   github: {
     clientId: import.meta.env.VITE_GITHUB_CLIENT_ID || '',

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/google.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/google.ts
@@ -1,255 +1,191 @@
 // ============================================================
-//  Google OAuth - Using Google Identity Services (GIS)
+//  Google OAuth - Redirect Flow (Backend Token Exchange)
+// ============================================================
+//
+//  This implementation uses the standard OAuth 2.0 authorization
+//  code flow with backend token exchange, similar to GitHub OAuth.
+//
+//  Flow:
+//  1. Frontend redirects to Google authorization
+//  2. Google redirects back with authorization code
+//  3. Frontend sends code to backend
+//  4. Backend exchanges code for tokens and creates user
+//
 // ============================================================
 
 import { oauthConfig, isGoogleConfigured } from './config'
-import type { OAuthResult, GoogleCredentialResponse, GoogleDecodedToken } from './types'
+import type { OAuthResult } from './types'
+import type { AuthUser } from '@/types/user-management'
 
-// Google Identity Services types (FedCM compatible)
-declare global {
-  interface Window {
-    google?: {
-      accounts: {
-        id: {
-          initialize: (config: {
-            client_id: string
-            callback: (response: GoogleCredentialResponse) => void
-            auto_select?: boolean
-            cancel_on_tap_outside?: boolean
-            use_fedcm_for_prompt?: boolean  // FedCM migration
-            itp_support?: boolean            // Intelligent Tracking Prevention
-          }) => void
-          prompt: (notification?: (notification: {
-            isNotDisplayed: () => boolean
-            isSkippedMoment: () => boolean
-            isDismissedMoment?: () => boolean
-            getMomentType?: () => string
-            getNotDisplayedReason: () => string
-            getSkippedReason: () => string
-            getDismissedReason?: () => string
-          }) => void) => void
-          renderButton: (
-            parent: HTMLElement,
-            options: {
-              type?: 'standard' | 'icon'
-              theme?: 'outline' | 'filled_blue' | 'filled_black'
-              size?: 'large' | 'medium' | 'small'
-              text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin'
-              shape?: 'rectangular' | 'pill' | 'circle' | 'square'
-              logo_alignment?: 'left' | 'center'
-              width?: number
-              locale?: string
-            }
-          ) => void
-          disableAutoSelect: () => void
-          cancel: () => void
-        }
-      }
-    }
-  }
-}
-
-// State
-let isInitialized = false
-let resolveCallback: ((result: OAuthResult) => void) | null = null
+// State key for CSRF protection
+const STATE_KEY = 'google_oauth_state'
 
 /**
- * Decode JWT token from Google
+ * Generate random state for CSRF protection
  */
-function decodeJwt(token: string): GoogleDecodedToken | null {
-  try {
-    const base64Url = token.split('.')[1]
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
-    const jsonPayload = decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-        .join('')
-    )
-    return JSON.parse(jsonPayload)
-  } catch {
-    return null
-  }
+function generateState(): string {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('')
 }
 
 /**
- * Handle Google credential response
+ * Start Google OAuth flow (redirect)
  */
-function handleCredentialResponse(response: GoogleCredentialResponse) {
-  const decoded = decodeJwt(response.credential)
-  
-  if (!decoded) {
-    resolveCallback?.({
-      success: false,
-      error: 'Failed to decode Google credential',
-    })
+export function initiateGoogleLogin(): void {
+  if (!isGoogleConfigured()) {
+    console.error('[OAuth] Google Client ID not configured')
     return
   }
 
-  resolveCallback?.({
-    success: true,
-    user: {
-      id: decoded.sub,
-      email: decoded.email,
-      name: decoded.name,
-      picture: decoded.picture,
-      provider: 'google',
-    },
-  })
-}
+  const state = generateState()
+  sessionStorage.setItem(STATE_KEY, state)
 
-/**
- * Load Google Identity Services SDK
- */
-export async function loadGoogleSdk(): Promise<boolean> {
-  if (!isGoogleConfigured()) {
-    console.warn('[OAuth] Google Client ID not configured')
-    return false
-  }
-
-  if (window.google?.accounts) {
-    return true
-  }
-
-  return new Promise((resolve) => {
-    const script = document.createElement('script')
-    script.src = 'https://accounts.google.com/gsi/client'
-    script.async = true
-    script.defer = true
-    script.onload = () => {
-      resolve(true)
-    }
-    script.onerror = () => {
-      console.error('[OAuth] Failed to load Google Identity Services')
-      resolve(false)
-    }
-    document.head.appendChild(script)
-  })
-}
-
-/**
- * Initialize Google Identity Services
- */
-export async function initializeGoogleAuth(): Promise<boolean> {
-  if (isInitialized) return true
-  
-  const loaded = await loadGoogleSdk()
-  if (!loaded || !window.google?.accounts) {
-    return false
-  }
-
-  // FedCM requires Privacy Policy & Terms of Service URLs in Google Console
-  // Set use_fedcm_for_prompt: false until Console is properly configured
-  const useFedCM = import.meta.env.VITE_GOOGLE_USE_FEDCM === 'true'
-  
-  window.google.accounts.id.initialize({
+  const params = new URLSearchParams({
     client_id: oauthConfig.google.clientId,
-    callback: handleCredentialResponse,
-    auto_select: false,
-    cancel_on_tap_outside: true,
-    use_fedcm_for_prompt: useFedCM,  // Enable FedCM when Console is configured
-    itp_support: true,               // Safari ITP support
+    redirect_uri: oauthConfig.google.redirectUri,
+    response_type: 'code',
+    scope: oauthConfig.google.scope,
+    state,
+    access_type: 'offline',      // Get refresh token
+    prompt: 'select_account',    // Always show account picker
   })
 
-  isInitialized = true
-  return true
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`
 }
 
 /**
- * Trigger Google Sign-In popup
+ * Handle Google OAuth callback
+ * This should be called when user returns from Google authorization
  */
-export async function signInWithGoogle(): Promise<OAuthResult> {
-  if (!isGoogleConfigured()) {
+export interface GoogleCallbackResult {
+  success: boolean
+  user?: AuthUser
+  error?: string
+}
+
+export async function handleGoogleCallback(
+  code: string,
+  state: string
+): Promise<GoogleCallbackResult> {
+  // Verify state for CSRF protection
+  const savedState = sessionStorage.getItem(STATE_KEY)
+  sessionStorage.removeItem(STATE_KEY)
+
+  if (!savedState || savedState !== state) {
     return {
       success: false,
-      error: 'Google OAuth not configured. Please set VITE_GOOGLE_CLIENT_ID.',
+      error: 'Invalid OAuth state. Please try again.',
     }
   }
 
-  const initialized = await initializeGoogleAuth()
-  if (!initialized) {
-    return {
-      success: false,
-      error: 'Failed to initialize Google Sign-In',
-    }
-  }
-
-  return new Promise((resolve) => {
-    resolveCallback = resolve
-    
-    // Use One Tap prompt with FedCM
-    window.google?.accounts.id.prompt((notification) => {
-      // FedCM compatible: check moment type if available
-      const momentType = notification.getMomentType?.() || 'unknown'
-      
-      if (notification.isNotDisplayed()) {
-        const reason = notification.getNotDisplayedReason()
-        console.info('[OAuth] One Tap not displayed:', reason)
-        resolve({
-          success: false,
-          error: `Google Sign-In unavailable: ${reason}. Try using the Google button.`,
-        })
-      } else if (notification.isSkippedMoment()) {
-        const reason = notification.getSkippedReason()
-        console.info('[OAuth] One Tap skipped:', reason)
-        resolve({
-          success: false,
-          error: `Google Sign-In skipped: ${reason}. Try using the Google button.`,
-        })
-      } else if (notification.isDismissedMoment?.()) {
-        const reason = notification.getDismissedReason?.() || 'user_cancel'
-        console.info('[OAuth] One Tap dismissed:', reason)
-        // User dismissed, don't show error - just resolve quietly
-        resolve({
-          success: false,
-          error: reason === 'credential_returned' ? '' : `Sign-in cancelled`,
-        })
-      }
-      // If none of above, credential callback will handle success
-      console.debug('[OAuth] One Tap moment:', momentType)
+  try {
+    const response = await fetch('/api/auth/google/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ code, state }),
     })
 
-    // Timeout after 60 seconds
-    setTimeout(() => {
-      if (resolveCallback === resolve) {
-        resolveCallback = null
-        resolve({
-          success: false,
-          error: 'Google Sign-In timed out',
-        })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      return {
+        success: false,
+        error: error.error || 'Google authentication failed',
       }
-    }, 60000)
-  })
-}
+    }
 
-/**
- * Render Google Sign-In button into container
- */
-export async function renderGoogleButton(containerId: string): Promise<boolean> {
-  const initialized = await initializeGoogleAuth()
-  if (!initialized) return false
+    const data = await response.json()
 
-  const container = document.getElementById(containerId)
-  if (!container) {
-    console.error(`[OAuth] Container #${containerId} not found`)
-    return false
+    return {
+      success: true,
+      user: data.user as AuthUser,
+    }
+  } catch (error) {
+    console.error('[OAuth] Google callback error:', error)
+    return {
+      success: false,
+      error: 'Failed to complete Google authentication',
+    }
   }
-
-  window.google?.accounts.id.renderButton(container, {
-    type: 'standard',
-    theme: 'filled_black',
-    size: 'large',
-    text: 'continue_with',
-    shape: 'rectangular',
-    width: 300,
-  })
-
-  return true
 }
 
 /**
- * Sign out from Google
+ * Check if current URL is Google callback
  */
+export function isGoogleCallback(): boolean {
+  const url = new URL(window.location.href)
+  return (
+    url.pathname === '/auth/callback/google' &&
+    url.searchParams.has('code') &&
+    url.searchParams.has('state')
+  )
+}
+
+/**
+ * Get Google callback parameters
+ */
+export function getGoogleCallbackParams(): { code: string; state: string } | null {
+  const url = new URL(window.location.href)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+
+  if (!code || !state) return null
+  return { code, state }
+}
+
+/**
+ * Mock Google OAuth for development (when backend is not available)
+ * This simulates a successful Google login
+ */
+export async function mockGoogleLogin(): Promise<OAuthResult> {
+  // Simulate network delay
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
+  return {
+    success: true,
+    user: {
+      id: 'google-mock-123',
+      email: 'developer@google.local',
+      name: 'Google Developer',
+      picture: 'https://lh3.googleusercontent.com/a/default-user',
+      provider: 'google',
+    },
+  }
+}
+
+// ============================================================
+//  Legacy exports for backward compatibility (deprecated)
+// ============================================================
+
+/** @deprecated Use initiateGoogleLogin instead */
+export async function signInWithGoogle(): Promise<OAuthResult> {
+  // Redirect flow - this function now initiates redirect
+  initiateGoogleLogin()
+  // Return pending state since we're redirecting
+  return {
+    success: false,
+    error: 'Redirecting to Google...',
+  }
+}
+
+/** @deprecated No longer needed with redirect flow */
+export async function loadGoogleSdk(): Promise<boolean> {
+  return true // No SDK needed for redirect flow
+}
+
+/** @deprecated No longer needed with redirect flow */
+export async function initializeGoogleAuth(): Promise<boolean> {
+  return true // No initialization needed for redirect flow
+}
+
+/** @deprecated No longer needed with redirect flow */
+export async function renderGoogleButton(_containerId: string): Promise<boolean> {
+  console.warn('[OAuth] renderGoogleButton is deprecated. Use initiateGoogleLogin instead.')
+  return false
+}
+
+/** @deprecated No longer needed with redirect flow */
 export function signOutGoogle() {
-  window.google?.accounts.id.disableAutoSelect()
+  // No-op for redirect flow
 }

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/index.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/index.ts
@@ -1,8 +1,35 @@
 // ============================================================
 //  OAuth Module - Unified Export
 // ============================================================
+//
+//  Both Google and GitHub use redirect flow with backend
+//  token exchange for security and ABP Identity integration.
+//
+// ============================================================
 
 export * from './config'
 export * from './types'
-export * from './google'
-export * from './github'
+
+// Google OAuth (redirect flow)
+export {
+  initiateGoogleLogin,
+  handleGoogleCallback,
+  isGoogleCallback,
+  getGoogleCallbackParams,
+  mockGoogleLogin,
+  // Legacy exports (deprecated)
+  signInWithGoogle,
+  loadGoogleSdk,
+  initializeGoogleAuth,
+  renderGoogleButton,
+  signOutGoogle,
+} from './google'
+
+// GitHub OAuth (redirect flow)
+export {
+  initiateGitHubLogin,
+  handleGitHubCallback,
+  isGitHubCallback,
+  getGitHubCallbackParams,
+  mockGitHubLogin,
+} from './github'

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/types.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/lib/oauth/types.ts
@@ -1,5 +1,10 @@
 // ============================================================
-//  OAuth Types
+//  OAuth Types - Redirect Flow
+// ============================================================
+//
+//  Both Google and GitHub use redirect flow with backend
+//  token exchange for security and ABP Identity integration.
+//
 // ============================================================
 
 export interface OAuthUser {
@@ -10,12 +15,24 @@ export interface OAuthUser {
   provider: 'google' | 'github'
 }
 
+export interface OAuthResult {
+  success: boolean
+  user?: OAuthUser
+  error?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Legacy types (kept for backward compatibility, may be removed)
+// ─────────────────────────────────────────────────────────────────────
+
+/** @deprecated No longer used with redirect flow */
 export interface GoogleCredentialResponse {
   credential: string
   select_by: string
   clientId: string
 }
 
+/** @deprecated No longer used with redirect flow */
 export interface GoogleDecodedToken {
   iss: string
   azp: string
@@ -32,16 +49,11 @@ export interface GoogleDecodedToken {
   exp: number
 }
 
+/** @deprecated Use backend response instead */
 export interface GitHubUser {
   id: number
   login: string
   name: string | null
   email: string | null
   avatar_url: string
-}
-
-export interface OAuthResult {
-  success: boolean
-  user?: OAuthUser
-  error?: string
 }

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/account/index.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/account/index.tsx
@@ -5,12 +5,15 @@ import {
   PasswordPanel,
 } from "@/components/account"
 import { UserProvidersTab } from "@/components/user-providers"
+import { useHasPassword } from "@/store/auth-store"
 
 // ============================================================
 //  Account Page - Routes to Account Panels (Basic Version)
 // ============================================================
 
 export default function AccountPage() {
+  const hasPassword = useHasPassword()
+
   return (
     <Routes>
       {/* Default redirect to profile */}
@@ -26,13 +29,17 @@ export default function AccountPage() {
         }
       />
 
-      {/* Password */}
+      {/* Password — only for local (non-OAuth) users */}
       <Route
         path="/password"
         element={
-          <AccountLayout title="Change Password" subtitle="Update your account password">
-            <PasswordPanel />
-          </AccountLayout>
+          hasPassword ? (
+            <AccountLayout title="Change Password" subtitle="Update your account password">
+              <PasswordPanel />
+            </AccountLayout>
+          ) : (
+            <Navigate to="/account/profile" replace />
+          )
         }
       />
 

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/auth/login.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/auth/login.tsx
@@ -8,26 +8,26 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/components/ui/toast"
 import { abpLogin, type AuthResponse } from "@/lib/abp"
+import { useAuthStore } from "@/store/auth-store"
+import {
+  isGoogleConfigured,
+  isGitHubConfigured,
+  initiateGoogleLogin,
+  initiateGitHubLogin,
+} from "@/lib/oauth"
 
 // Demo credentials for testing (remove in production)
 const getDemoCredentials = () => ({
   admin: { email: "admin", password: "1q2w3E*" },  // ABP default
   user: { email: "testuser", password: "Abc@123" },
 })
-import { useAuthStore } from "@/store/auth-store"
-import {
-  isGoogleConfigured,
-  isGitHubConfigured,
-  signInWithGoogle,
-  initiateGitHubLogin,
-} from "@/lib/oauth"
-import type { OAuthUser } from "@/lib/oauth"
 
 // OAuth feature flag - set VITE_ENABLE_OAUTH=false to disable
 const OAUTH_ENABLED = import.meta.env.VITE_ENABLE_OAUTH !== 'false'
 
 // ============================================================
 //  Login Page - Email/Password + OAuth Social Login
+//  Both Google and GitHub use redirect flow for security
 // ============================================================
 
 export default function LoginPage() {
@@ -76,53 +76,23 @@ export default function LoginPage() {
     }
   }
 
-  // Convert OAuth user to AuthUser format
-  const convertOAuthUser = (oauthUser: OAuthUser) => ({
-    id: oauthUser.id,
-    userName: oauthUser.email.split('@')[0],
-    email: oauthUser.email,
-    name: oauthUser.name.split(' ')[0] || oauthUser.name,
-    surname: oauthUser.name.split(' ').slice(1).join(' ') || undefined,
-    roles: ['member'],
-    isAdmin: false,
-    avatarUrl: oauthUser.picture,
-  })
-
-  const handleGoogleLogin = async () => {
-    setIsLoading(true)
-
-    try {
-      if (isGoogleConfigured()) {
-        // Real Google OAuth with FedCM
-        const result = await signInWithGoogle()
-        
-        if (result.success && result.user) {
-          login(convertOAuthUser(result.user))
-          navigate("/app")
-        } else {
-          // Show user-friendly message
-          const friendlyError = result.error?.includes('unavailable') || result.error?.includes('skipped')
-            ? "Please sign in to Google in your browser first, or use email/password login."
-            : (result.error || "Google login failed")
-          showError(friendlyError)
-        }
-      } else {
-        // Google OAuth not configured
-        showError("Google OAuth not configured. Please use email/password login.")
-      }
-    } catch {
-      showError("An unexpected error occurred. Please try again.")
-    } finally {
-      setIsLoading(false)
+  const handleGoogleLogin = () => {
+    if (isGoogleConfigured()) {
+      // Google OAuth - redirect flow (same as GitHub)
+      setIsLoading(true)
+      initiateGoogleLogin()
+      // Page will redirect to Google, callback handled by oauth-callback page
+    } else {
+      showError("Google OAuth not configured. Please use email/password login.")
     }
   }
 
-  const handleGithubLogin = async () => {
+  const handleGithubLogin = () => {
     if (isGitHubConfigured()) {
-      // Real GitHub OAuth - redirect flow
+      // GitHub OAuth - redirect flow
       setIsLoading(true)
       initiateGitHubLogin()
-      // Page will redirect, no need to handle response here
+      // Page will redirect to GitHub, callback handled by oauth-callback page
     } else {
       showError("GitHub OAuth not configured. Please use email/password login.")
     }

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/auth/oauth-callback.tsx
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/pages/auth/oauth-callback.tsx
@@ -1,22 +1,32 @@
 import { useEffect, useRef, useState } from "react"
-import { useNavigate, useSearchParams } from "react-router-dom"
+import { useNavigate, useSearchParams, useLocation } from "react-router-dom"
 import { Loader2, AlertCircle, CheckCircle } from "lucide-react"
 import { AuthLayout } from "@/components/auth"
 import { Button } from "@/components/ui/button"
 import { useAuthStore } from "@/store/auth-store"
-import { handleGitHubCallback } from "@/lib/oauth"
+import { handleGitHubCallback, handleGoogleCallback } from "@/lib/oauth"
 
 // ============================================================
-//  OAuth Callback Page - Handles GitHub redirect
+//  OAuth Callback Page - Handles GitHub & Google redirects
 // ============================================================
+
+type OAuthProvider = "github" | "google" | "unknown"
+
+function detectProvider(pathname: string): OAuthProvider {
+  if (pathname.includes("/callback/github")) return "github"
+  if (pathname.includes("/callback/google")) return "google"
+  return "unknown"
+}
 
 export default function OAuthCallbackPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams] = useSearchParams()
   const { login } = useAuthStore()
   
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading")
   const [message, setMessage] = useState("Processing authentication...")
+  const [provider, setProvider] = useState<OAuthProvider>("unknown")
   const calledRef = useRef(false)
 
   useEffect(() => {
@@ -26,12 +36,15 @@ export default function OAuthCallbackPage() {
   }, [])
 
   const handleCallback = async () => {
+    const detectedProvider = detectProvider(location.pathname)
+    setProvider(detectedProvider)
+
     const code = searchParams.get("code")
     const state = searchParams.get("state")
     const error = searchParams.get("error")
     const errorDescription = searchParams.get("error_description")
 
-    // Handle OAuth error
+    // Handle OAuth error from provider
     if (error) {
       setStatus("error")
       setMessage(errorDescription || `OAuth error: ${error}`)
@@ -45,10 +58,19 @@ export default function OAuthCallbackPage() {
       return
     }
 
+    if (detectedProvider === "unknown") {
+      setStatus("error")
+      setMessage("Unknown OAuth provider. Please try again.")
+      return
+    }
+
     try {
-      setMessage("Completing authentication...")
+      setMessage(`Completing ${detectedProvider === "github" ? "GitHub" : "Google"} authentication...`)
       
-      const result = await handleGitHubCallback(code, state)
+      // Call the appropriate handler based on provider
+      const result = detectedProvider === "github"
+        ? await handleGitHubCallback(code, state)
+        : await handleGoogleCallback(code, state)
 
       if (result.success && result.user) {
         setStatus("success")
@@ -70,10 +92,12 @@ export default function OAuthCallbackPage() {
     }
   }
 
+  const providerName = provider === "github" ? "GitHub" : provider === "google" ? "Google" : "OAuth"
+
   return (
     <AuthLayout
       title={
-        status === "loading" ? "Authenticating..." :
+        status === "loading" ? `Authenticating with ${providerName}...` :
         status === "success" ? "Success!" :
         "Authentication Failed"
       }

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/store/auth-store.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/store/auth-store.ts
@@ -57,3 +57,6 @@ export const useAuthStore = create<AuthState>()(
 export const useIsAdmin = () => useAuthStore((state) => state.user?.isAdmin ?? false)
 export const useCurrentUser = () => useAuthStore((state) => state.user)
 export const useIsAuthenticated = () => useAuthStore((state) => state.isAuthenticated)
+export const useHasPassword = () => useAuthStore((state) =>
+  !state.user?.loginProvider || state.user.loginProvider === 'local'
+)

--- a/apps/Aevatar.VibeResearching/sisyphus-frontend/src/types/user-management.ts
+++ b/apps/Aevatar.VibeResearching/sisyphus-frontend/src/types/user-management.ts
@@ -136,6 +136,7 @@ export interface AuthUser {
   roles: string[]
   isAdmin: boolean
   avatarUrl?: string
+  loginProvider?: 'local' | 'Google' | 'GitHub'  // OAuth users have no password
 }
 
 export interface AuthState {

--- a/apps/Aevatar.VibeResearching/src/host/HttpApi.Host/MinimalApis/AuthEndpoints.cs
+++ b/apps/Aevatar.VibeResearching/src/host/HttpApi.Host/MinimalApis/AuthEndpoints.cs
@@ -10,6 +10,9 @@ namespace Aevatar.VibeResearching.HttpApi.Host.MinimalApis;
 
 public static class AuthEndpoints
 {
+    // ─────────────────────────────────────────────────────────────────────
+    // Shared HTTP clients for OAuth providers
+    // ─────────────────────────────────────────────────────────────────────
     private static readonly HttpClient GitHubHttp = new()
     {
         Timeout = TimeSpan.FromSeconds(15),
@@ -17,6 +20,15 @@ public static class AuthEndpoints
         {
             Accept = { new MediaTypeWithQualityHeaderValue("application/json") },
             UserAgent = { new ProductInfoHeaderValue("AevatarVibeResearching", "1.0") }
+        }
+    };
+
+    private static readonly HttpClient GoogleHttp = new()
+    {
+        Timeout = TimeSpan.FromSeconds(15),
+        DefaultRequestHeaders =
+        {
+            Accept = { new MediaTypeWithQualityHeaderValue("application/json") }
         }
     };
 
@@ -275,6 +287,178 @@ public static class AuthEndpoints
                     roles = roles.ToList(),
                     isAdmin,
                     avatarUrl = ghUser.AvatarUrl,
+                    loginProvider = "GitHub",
+                }
+            });
+        }).AllowAnonymous();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // POST /api/auth/google/callback — Exchange Google code for user session
+        // Frontend sends the authorization code; backend exchanges it for a
+        // Google access token, fetches the user profile, creates or finds
+        // the ABP Identity user, signs in, and returns user info.
+        // ─────────────────────────────────────────────────────────────────────
+        app.MapPost("/api/auth/google/callback", async (
+            GoogleCallbackRequest request,
+            IConfiguration configuration,
+            UserManager<Volo.Abp.Identity.IdentityUser> userManager,
+            SignInManager<Volo.Abp.Identity.IdentityUser> signInManager,
+            IdentityRoleManager roleManager,
+            ILoggerFactory loggerFactory) =>
+        {
+            var logger = loggerFactory.CreateLogger("AuthEndpoints.GoogleCallback");
+
+            if (string.IsNullOrWhiteSpace(request.Code))
+                return Results.BadRequest(new { error = "Authorization code is required." });
+
+            if (string.IsNullOrWhiteSpace(request.State))
+                return Results.BadRequest(new { error = "OAuth state parameter is required." });
+
+            var clientId = configuration["Google:ClientId"];
+            var clientSecret = configuration["Google:ClientSecret"];
+            var redirectUri = configuration["Google:RedirectUri"] ?? "http://localhost:5173/auth/callback/google";
+
+            if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+                return Results.Json(new { error = "Google OAuth is not configured." }, statusCode: 500);
+
+            // 1. Exchange code → access token
+            var tokenPayload = new Dictionary<string, string>
+            {
+                ["client_id"] = clientId,
+                ["client_secret"] = clientSecret,
+                ["code"] = request.Code,
+                ["grant_type"] = "authorization_code",
+                ["redirect_uri"] = redirectUri,
+            };
+
+            var tokenResp = await GoogleHttp.PostAsync(
+                "https://oauth2.googleapis.com/token",
+                new FormUrlEncodedContent(tokenPayload));
+
+            if (!tokenResp.IsSuccessStatusCode)
+            {
+                var errBody = await tokenResp.Content.ReadAsStringAsync();
+                logger.LogWarning("Google token exchange failed: {Status} - {Body}",
+                    tokenResp.StatusCode, errBody);
+                return Results.Json(new { error = "Authentication failed. Please try again." }, statusCode: 502);
+            }
+
+            var tokenData = await tokenResp.Content.ReadFromJsonAsync<GoogleTokenResponse>();
+            if (tokenData is null || string.IsNullOrEmpty(tokenData.AccessToken))
+            {
+                logger.LogWarning("Google token exchange returned empty access_token");
+                return Results.Json(new { error = "Authentication failed. Please try again." }, statusCode: 502);
+            }
+
+            // 2. Fetch Google user profile
+            using var userReq = new HttpRequestMessage(HttpMethod.Get, "https://www.googleapis.com/oauth2/v2/userinfo");
+            userReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenData.AccessToken);
+
+            var userResp = await GoogleHttp.SendAsync(userReq);
+            if (!userResp.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Google userinfo fetch failed: {Status}", userResp.StatusCode);
+                return Results.Json(new { error = "Authentication failed. Please try again." }, statusCode: 502);
+            }
+
+            var googleUser = await userResp.Content.ReadFromJsonAsync<GoogleUserInfo>();
+            if (googleUser is null || string.IsNullOrEmpty(googleUser.Id))
+                return Results.Json(new { error = "Authentication failed. Please try again." }, statusCode: 502);
+
+            // 3. Require verified email
+            if (string.IsNullOrEmpty(googleUser.Email))
+            {
+                return Results.Json(new
+                {
+                    error = "A verified email address is required. Please use a Google account with a verified email."
+                }, statusCode: 400);
+            }
+
+            if (!googleUser.VerifiedEmail)
+            {
+                return Results.Json(new
+                {
+                    error = "Your Google email is not verified. Please verify your email in your Google account."
+                }, statusCode: 400);
+            }
+
+            // 4. Find or create ABP Identity user
+            var user = await userManager.FindByLoginAsync("Google", googleUser.Id);
+
+            if (user is null)
+            {
+                // Check if email already belongs to an existing account
+                var existingByEmail = await userManager.FindByEmailAsync(googleUser.Email);
+
+                if (existingByEmail is not null)
+                {
+                    logger.LogInformation(
+                        "Google OAuth: email {Email} matches existing user {UserId}, refusing auto-link",
+                        googleUser.Email, existingByEmail.Id);
+                    return Results.Json(new
+                    {
+                        error = "An account with this email already exists. Please sign in with your password first, then link your Google account from settings."
+                    }, statusCode: 409);
+                }
+
+                // Create new user - use email prefix as username
+                var userName = googleUser.Email.Split('@')[0];
+
+                // Ensure username is unique
+                var existing = await userManager.FindByNameAsync(userName);
+                if (existing is not null)
+                    userName = $"{userName}_{googleUser.Id[..8]}";
+
+                user = new Volo.Abp.Identity.IdentityUser(
+                    Guid.NewGuid(),
+                    userName,
+                    googleUser.Email);
+
+                user.SetIsActive(true);
+
+                // Set display name
+                if (!string.IsNullOrEmpty(googleUser.GivenName))
+                    user.Name = googleUser.GivenName;
+                if (!string.IsNullOrEmpty(googleUser.FamilyName))
+                    user.Surname = googleUser.FamilyName;
+
+                var createResult = await userManager.CreateAsync(user);
+                if (!createResult.Succeeded)
+                {
+                    logger.LogError("Failed to create user for Google {Email}: {Errors}",
+                        googleUser.Email,
+                        string.Join("; ", createResult.Errors.Select(e => e.Description)));
+                    return Results.Json(new { error = "Account creation failed. Please try again." }, statusCode: 500);
+                }
+
+                // Assign default "member" role
+                if (await roleManager.RoleExistsAsync("member"))
+                    await userManager.AddToRoleAsync(user, "member");
+
+                // Link Google login to user
+                await userManager.AddLoginAsync(user, new UserLoginInfo("Google", googleUser.Id, "Google"));
+            }
+
+            // 5. Sign in (creates Identity cookie)
+            await signInManager.SignInAsync(user, isPersistent: false);
+
+            // 6. Return ABP Identity user info
+            var roles = await userManager.GetRolesAsync(user);
+            var isAdmin = roles.Contains("admin", StringComparer.OrdinalIgnoreCase);
+
+            return Results.Ok(new
+            {
+                user = new
+                {
+                    id = user.Id.ToString(),
+                    userName = user.UserName,
+                    email = user.Email,
+                    name = user.Name,
+                    surname = user.Surname,
+                    roles = roles.ToList(),
+                    isAdmin,
+                    avatarUrl = googleUser.Picture,
+                    loginProvider = "Google",
                 }
             });
         }).AllowAnonymous();
@@ -350,4 +534,73 @@ internal sealed class GitHubEmail
 
     [JsonPropertyName("verified")]
     public bool Verified { get; set; }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Google OAuth Models
+// ─────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Request model for POST /api/auth/google/callback
+/// </summary>
+public record GoogleCallbackRequest(string Code, string? State = null);
+
+/// <summary>
+/// Google token exchange response
+/// </summary>
+internal sealed class GoogleTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public int? ExpiresIn { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    [JsonPropertyName("token_type")]
+    public string? TokenType { get; set; }
+
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; set; }
+}
+
+/// <summary>
+/// Google user profile from /oauth2/v2/userinfo API
+/// </summary>
+internal sealed class GoogleUserInfo
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("verified_email")]
+    public bool VerifiedEmail { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+
+    [JsonPropertyName("locale")]
+    public string? Locale { get; set; }
 }

--- a/apps/Aevatar.VibeResearching/src/host/HttpApi.Host/VibeResearchingHttpApiHostModule.cs
+++ b/apps/Aevatar.VibeResearching/src/host/HttpApi.Host/VibeResearchingHttpApiHostModule.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Volo.Abp.AspNetCore.Mvc.AntiForgery;
+using Volo.Abp.AspNetCore.Mvc.Libs;
 using Aevatar.Agents.AI.Abstractions.Configuration;
 using Aevatar.Agents.AI.Core.Configuration;
 using Aevatar.Agents.AI.DependencyInjection;
@@ -189,6 +190,12 @@ public class VibeResearchingHttpApiHostModule : AbpModule
         Configure<AbpAntiForgeryOptions>(options =>
         {
             options.AutoValidate = false;
+        });
+
+        // Disable ABP Libs folder check (API-only host, no MVC views)
+        Configure<AbpMvcLibsOptions>(options =>
+        {
+            options.CheckLibs = false;
         });
 
         // ==========================================


### PR DESCRIPTION
…d integration

- Rewrite Google OAuth to use standard OAuth 2.0 authorization code flow with backend token exchange, matching GitHub OAuth pattern
- Add POST /api/auth/google/callback endpoint for Google code → token exchange, user profile fetch, and ABP Identity user creation
- Add loginProvider field to AuthUser and backend OAuth responses to distinguish OAuth users from local password users
- Hide Password UI for OAuth users across all entry points: user-menu, account-sidebar, admin-sidebar, profile-panel security section, and account/password route guard
- Update oauth-callback page to handle both Google and GitHub providers
- Hide Platform Settings menu item for non-admin users
- Disable ABP MVC Libs check for API-only host