### PR TITLE
refactor: Orleans runtime optimizations and framework cleanup

### DIFF
--- a/plugins/Aevatar.Agents.Plugins.MassTransit/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/plugins/Aevatar.Agents.Plugins.MassTransit/DependencyInjection/ServiceCollectionExtensions.cs
@@ -330,11 +330,21 @@ public static class ServiceCollectionExtensions
 
                             if (options.Consumer.Enabled)
                             {
+                                // Broadcast Mode for LocalHandler (HttpApi):
+                                // Each instance uses a unique ConsumerGroupId so all instances receive all messages.
+                                // Messages are filtered locally by checking if there's a subscriber for the StreamId.
+                                // This is how Orleans Stream works for Clients - simple and reliable.
+                                var baseGroupId = options.Kafka?.ConsumerGroupId ?? "aevatar-agents-group";
+                                var isBroadcastMode = options.Consumer.DispatchHandler == DispatchHandler.LocalHandler;
+                                var consumerGroupId = isBroadcastMode
+                                    ? $"{baseGroupId}-{Environment.MachineName}-{System.Diagnostics.Process.GetCurrentProcess().Id}"
+                                    : baseGroupId;
+                                
                                 foreach (var topic in consumerTopics)
                                 {
                                     k.TopicEndpoint<ByteArrayMessage>(
                                         topic, 
-                                        options.Kafka?.ConsumerGroupId ?? "aevatar-agents-group", 
+                                        consumerGroupId, 
                                         e =>
                                         {
                                             e.AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest;

--- a/plugins/Aevatar.Agents.Plugins.MassTransit/ITraceIdExtractor.cs
+++ b/plugins/Aevatar.Agents.Plugins.MassTransit/ITraceIdExtractor.cs
@@ -1,0 +1,23 @@
+using Aevatar.Agents.Abstractions;
+
+namespace Aevatar.Agents.Plugins.MassTransit;
+
+/// <summary>
+/// Pluggable trace ID extractor for MassTransit message dispatching.
+/// 
+/// Implementations can extract application-specific correlation/trace IDs
+/// from event envelopes for logging and distributed tracing.
+/// 
+/// Register via DI to enable:
+///   services.AddSingleton&lt;ITraceIdExtractor, MyAppTraceIdExtractor&gt;();
+/// </summary>
+public interface ITraceIdExtractor
+{
+    /// <summary>
+    /// Try to extract a trace ID from the given event envelope.
+    /// </summary>
+    /// <param name="envelope">The parsed event envelope.</param>
+    /// <param name="traceId">The extracted trace ID, or null if not applicable.</param>
+    /// <returns>True if a trace ID was successfully extracted.</returns>
+    bool TryExtract(EventEnvelope envelope, out string? traceId);
+}

--- a/plugins/Aevatar.Agents.Plugins.MassTransit/MassTransitMessageStream.cs
+++ b/plugins/Aevatar.Agents.Plugins.MassTransit/MassTransitMessageStream.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using Aevatar.Agents.Abstractions;
 using Google.Protobuf;
 using MassTransit;
@@ -124,6 +125,18 @@ public class MassTransitMessageStream : IMessageStream
         };
 
         _handlers.TryAdd(subscriptionId, wrapperHandler);
+        
+        // Log with explicit format to show actual value (not Serilog-quoted)
+        _logger.LogInformation("[MassTransitMessageStream] Handler REGISTERED - StreamId='{StreamId}', StreamIdLength={Length}, SubscriptionId={SubscriptionId}, HandlerType={HandlerType}, TotalHandlers={Total}",
+            StreamId, StreamId?.Length ?? 0, subscriptionId, typeof(T).Name, _handlers.Count);
+        
+        // Also log raw bytes to detect hidden characters
+        if (!string.IsNullOrEmpty(StreamId))
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(StreamId);
+            var hex = string.Join(" ", bytes.Take(50).Select(b => b.ToString("X2")));
+            _logger.LogDebug("[MassTransitMessageStream] StreamId raw bytes (first 50): {Hex}", hex);
+        }
 
         return Task.FromResult<IMessageStreamSubscription>(
             new MassTransitMessageStreamSubscription(
@@ -131,6 +144,8 @@ public class MassTransitMessageStream : IMessageStream
                 StreamId, 
                 () => {
                     _handlers.TryRemove(subscriptionId, out _);
+                    _logger.LogDebug("[MassTransitMessageStream] Handler UNREGISTERED - StreamId={StreamId}, SubscriptionId={SubscriptionId}, RemainingHandlers={Remaining}",
+                        StreamId, subscriptionId, _handlers.Count);
                     return Task.CompletedTask;
                 }));
     }

--- a/plugins/Aevatar.Agents.Plugins.MassTransit/MassTransitMessageStreamProvider.cs
+++ b/plugins/Aevatar.Agents.Plugins.MassTransit/MassTransitMessageStreamProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using Aevatar.Agents.Abstractions;
 using MassTransit;
 using MassTransit.KafkaIntegration;
@@ -84,8 +85,32 @@ public class MassTransitMessageStreamProvider : IMessageStreamProvider
         // A stream instance is tied to an AgentId. 
         // If we create it with a category, that category determines where it publishes TO.
         
-        return _streams.GetOrAdd(agentId, id => 
-            new MassTransitMessageStream(id, category, _bus, _serviceProvider, _options));
+        var logger = _serviceProvider.GetService<ILogger<MassTransitMessageStreamProvider>>();
+        var isNew = !_streams.ContainsKey(agentId);
+        
+        var stream = _streams.GetOrAdd(agentId, id => 
+        {
+            logger?.LogInformation("[MassTransitMessageStreamProvider] Creating NEW stream - StreamId='{StreamId}', StreamIdLength={Length}, Category={Category}, TotalStreams={Total}",
+                id, id?.Length ?? 0, category ?? "null", _streams.Count + 1);
+            
+            // Log raw bytes to detect hidden characters
+            if (!string.IsNullOrEmpty(id))
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(id);
+                var hex = string.Join(" ", bytes.Take(50).Select(b => b.ToString("X2")));
+                logger?.LogDebug("[MassTransitMessageStreamProvider] StreamId raw bytes (first 50): {Hex}", hex);
+            }
+            
+            return new MassTransitMessageStream(id, category, _bus, _serviceProvider, _options);
+        });
+        
+        if (!isNew)
+        {
+            logger?.LogDebug("[MassTransitMessageStreamProvider] Using EXISTING stream - StreamId={StreamId}, Category={Category}, TotalStreams={Total}",
+                agentId, category ?? "null", _streams.Count);
+        }
+        
+        return stream;
     }
 
     /// <summary>
@@ -94,7 +119,32 @@ public class MassTransitMessageStreamProvider : IMessageStreamProvider
     /// </summary>
     internal MassTransitMessageStream? GetStreamInternal(string streamId)
     {
-        _streams.TryGetValue(streamId, out var stream);
+        // Defensive: Try lookup with stripped quotes if direct lookup fails
+        var found = _streams.TryGetValue(streamId, out var stream);
+        
+        if (!found && !string.IsNullOrEmpty(streamId))
+        {
+            // Try stripping quotes and lookup again
+            var stripped = streamId.Trim('"', '\'', '\u201C', '\u201D', ' ', '\t');
+            if (stripped.Length != streamId.Length)
+            {
+                found = _streams.TryGetValue(stripped, out stream);
+                if (found)
+                {
+                    var logger = _serviceProvider.GetService<ILogger<MassTransitMessageStreamProvider>>();
+                    logger?.LogDebug("[MassTransitMessageStreamProvider] Stream found after quote stripping: '{Original}' -> '{Stripped}'",
+                        streamId, stripped);
+                }
+            }
+        }
+        
+        if (!found)
+        {
+            var logger = _serviceProvider.GetService<ILogger<MassTransitMessageStreamProvider>>();
+            logger?.LogWarning("[MassTransitMessageStreamProvider] Stream NOT FOUND - StreamId='{StreamId}', TotalRegistered={Total}, RegisteredStreams=[{Streams}]",
+                streamId, _streams.Count, string.Join(", ", _streams.Keys.Take(10)));
+        }
+        
         return stream;
     }
 
@@ -102,4 +152,28 @@ public class MassTransitMessageStreamProvider : IMessageStreamProvider
     /// Gets all registered stream IDs (for debugging).
     /// </summary>
     internal IEnumerable<string> GetAllStreamIds() => _streams.Keys;
+
+    /// <summary>
+    /// Fast check if there's a local subscriber for the given streamId.
+    /// Used by StreamMessageDispatcher for early filtering in broadcast mode.
+    /// This is O(1) lookup - no heavy processing.
+    /// </summary>
+    internal bool HasSubscriber(string streamId)
+    {
+        if (string.IsNullOrEmpty(streamId))
+            return false;
+
+        // Direct lookup
+        if (_streams.TryGetValue(streamId, out var stream) && stream.GetHandlerCount() > 0)
+            return true;
+
+        // Defensive: try with stripped quotes
+        var stripped = streamId.Trim('"', '\'', '\u201C', '\u201D', ' ', '\t');
+        if (stripped.Length != streamId.Length && 
+            _streams.TryGetValue(stripped, out stream) && 
+            stream.GetHandlerCount() > 0)
+            return true;
+
+        return false;
+    }
 }

--- a/plugins/Aevatar.Agents.Plugins.MassTransit/StreamMessageDispatcher.cs
+++ b/plugins/Aevatar.Agents.Plugins.MassTransit/StreamMessageDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Aevatar.Agents.Abstractions;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Google.Protobuf;
 
 namespace Aevatar.Agents.Plugins.MassTransit;
 
@@ -17,11 +19,13 @@ namespace Aevatar.Agents.Plugins.MassTransit;
 /// Dispatch modes (configurable via Consumer.DispatchMode):
 /// - GrainOnly: Only dispatch to Grain handlers (Silo, best performance)
 /// - LocalStreamOnly: Only dispatch to local memory streams (HttpApi Client)
+/// - Both: Dispatch to both (for debugging)
 /// </summary>
 public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
 {
     private readonly IEnumerable<IMassTransitEventHandler> _eventHandlers;
     private readonly IEnumerable<IStreamNotFoundHandler> _notFoundHandlers;
+    private readonly IEnumerable<ITraceIdExtractor> _traceIdExtractors;
     private readonly ILogger<StreamMessageDispatcher> _logger;
     private readonly IServiceProvider? _serviceProvider;
     private readonly DispatchHandler _dispatchHandler;
@@ -30,16 +34,16 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
         IEnumerable<IMassTransitEventHandler> eventHandlers,
         IEnumerable<IStreamNotFoundHandler> notFoundHandlers,
         ILogger<StreamMessageDispatcher> logger,
+        IEnumerable<ITraceIdExtractor>? traceIdExtractors = null,
         IOptions<MassTransitStreamOptions>? options = null,
         IServiceProvider? serviceProvider = null)
     {
         _eventHandlers = eventHandlers;
         _notFoundHandlers = notFoundHandlers;
+        _traceIdExtractors = traceIdExtractors ?? Enumerable.Empty<ITraceIdExtractor>();
         _logger = logger;
         _serviceProvider = serviceProvider;
         _dispatchHandler = options?.Value?.Consumer?.DispatchHandler ?? DispatchHandler.GrainHandler;
-        
-        _logger.LogInformation("StreamMessageDispatcher initialized with DispatchHandler: {DispatchHandler}", _dispatchHandler);
     }
 
     public async Task Consume(ConsumeContext<ByteArrayMessage> context)
@@ -54,9 +58,25 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
             return;
         }
         
-        _logger.LogDebug("Received message for StreamId {StreamId}, DispatchHandler: {DispatchHandler}", streamId, _dispatchHandler);
+        // ============================================================
+        // EARLY FILTER: For LocalHandler (broadcast mode), check if we have
+        // a local subscriber BEFORE any heavy processing (deserialization, reflection).
+        // This is O(1) lookup - avoids wasting resources on irrelevant messages.
+        // ============================================================
+        if (_dispatchHandler == DispatchHandler.LocalHandler)
+        {
+            var streamProvider = _serviceProvider?.GetService<MassTransitMessageStreamProvider>();
+            if (streamProvider == null || !streamProvider.HasSubscriber(streamId))
+            {
+                // No local subscriber - skip immediately without heavy processing
+                // Silent return - this is expected in broadcast mode
+                return;
+            }
+        }
         
-        // Parse the envelope first
+        // === Proceed with heavy processing only for relevant messages ===
+        
+        // Parse the envelope
         EventEnvelope envelope;
         try
         {
@@ -64,66 +84,127 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
         }
         catch (System.Exception ex)
         {
-            _logger.LogError(ex, "Failed to parse EventEnvelope for StreamId {StreamId}", streamId);
+            _logger.LogError(ex, "[StreamMessageDispatcher] Failed to parse EventEnvelope for StreamId {StreamId}", streamId);
             throw;
         }
+        
+        // Extract TraceId via pluggable extractors (application-specific)
+        var traceId = ExtractTraceId(envelope);
+        var traceIdPrefix = traceId != null ? $"[TraceId={traceId}]" : "";
+        
+        // Defensive: Strip quotes from StreamId if present
+        streamId = SanitizeStreamId(streamId, traceIdPrefix);
+        
+        _logger.LogDebug(
+            "[StreamMessageDispatcher]{TraceId} Consuming message - StreamId='{StreamId}', DispatchHandler={DispatchHandler}",
+            traceIdPrefix, streamId, _dispatchHandler);
         
         // ============================================================
         // Dispatch based on configured handler type
         // ============================================================
         if (_dispatchHandler == DispatchHandler.LocalHandler)
         {
-            // LocalHandler: Dispatch to local memory stream subscribers (HttpApi Client)
-            var dispatched = await TryDispatchToLocalStreamAsync(streamId, data, envelope);
-            if (!dispatched)
-            {
-                _logger.LogDebug("LocalHandler: No local subscribers for StreamId {StreamId}", streamId);
-            }
+            await TryDispatchToLocalStreamAsync(streamId, data, envelope);
             return;
         }
         
         // GrainHandler: Dispatch to Grain handlers (Silo)
         var handled = await TryDispatchToGrainHandlersAsync(streamId, envelope);
-        if (handled)
-        {
-            return;
-        }
+        if (handled) return;
         
         // Try activation handlers and retry
         handled = await TryActivateAndRetryAsync(streamId, envelope);
-        if (handled)
-        {
-            return;
-        }
+        if (handled) return;
         
         // If still not handled, throw to trigger MassTransit retry
-        _logger.LogWarning("GrainHandler: No handler for StreamId {StreamId}. Throwing to trigger retry.", streamId);
-        throw new System.InvalidOperationException($"No handler for StreamId {streamId}. Actor might be failing to activate.");
+        _logger.LogWarning("Message dropped - StreamId={StreamId}, Reason=NoHandler (will retry)", streamId);
+        throw new System.InvalidOperationException(
+            $"No handler for StreamId {streamId}. Actor might be failing to activate.");
+    }
+
+    /// <summary>
+    /// Extract trace ID from envelope using registered ITraceIdExtractor implementations.
+    /// Returns null if no extractor matches.
+    /// </summary>
+    private string? ExtractTraceId(EventEnvelope envelope)
+    {
+        foreach (var extractor in _traceIdExtractors)
+        {
+            try
+            {
+                if (extractor.TryExtract(envelope, out var traceId) && !string.IsNullOrEmpty(traceId))
+                    return traceId;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex,
+                    "[StreamMessageDispatcher] TraceIdExtractor {Extractor} failed for TypeUrl={TypeUrl}",
+                    extractor.GetType().Name, envelope.Payload?.TypeUrl);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Sanitize StreamId by stripping stray quotes from edge-case JSON serialization.
+    /// </summary>
+    private string SanitizeStreamId(string streamId, string traceIdPrefix)
+    {
+        if (string.IsNullOrEmpty(streamId)) return streamId;
+
+        var stripped = streamId.Trim('"', '\'', '\u201C', '\u201D', ' ', '\t');
+        if (stripped.Length != streamId.Length)
+        {
+            _logger.LogDebug(
+                "[StreamMessageDispatcher]{TraceId} Stripped quotes from StreamId: '{Original}' -> '{Stripped}'",
+                traceIdPrefix, streamId, stripped);
+            return stripped;
+        }
+        return streamId;
     }
     
     /// <summary>
     /// Dispatch to local memory stream subscribers (e.g., ChatMiddleware in HttpApi)
     /// </summary>
-    private async Task<bool> TryDispatchToLocalStreamAsync(string streamId, byte[] data, EventEnvelope envelope)
+    private async Task<bool> TryDispatchToLocalStreamAsync(
+        string streamId, byte[] data, EventEnvelope envelope)
     {
         if (_serviceProvider == null)
         {
+            _logger.LogWarning("Message dropped - StreamId={StreamId}, Reason=ServiceProviderNull", streamId);
             return false;
         }
         
         try
         {
             var streamProvider = _serviceProvider.GetService<MassTransitMessageStreamProvider>();
-            if (streamProvider != null)
+            if (streamProvider == null)
             {
-                var localStream = streamProvider.GetStreamInternal(streamId);
-                if (localStream != null)
+                _logger.LogWarning("Message dropped - StreamId={StreamId}, Reason=StreamProviderNotFound", streamId);
+                return false;
+            }
+            
+            var localStream = streamProvider.GetStreamInternal(streamId);
+            if (localStream != null)
+            {
+                var handlerCount = localStream.GetHandlerCount();
+                if (handlerCount == 0)
                 {
-                    await localStream.DispatchAsync(data);
-                    _logger.LogDebug("Event {EventId} dispatched to local stream subscribers for StreamId {StreamId}", 
-                        envelope.Id, streamId);
-                    return true;
+                    _logger.LogWarning(
+                        "Message dropped - StreamId={StreamId}, Reason=NoHandlers (race condition)",
+                        streamId);
+                    return false;
                 }
+                
+                await localStream.DispatchAsync(data);
+                _logger.LogInformation(
+                    "Message dispatched - StreamId={StreamId}, Handlers={HandlerCount}",
+                    streamId, handlerCount);
+                return true;
+            }
+            else
+            {
+                _logger.LogWarning("Message dropped - StreamId={StreamId}, Reason=StreamNotFound", streamId);
             }
         }
         catch (System.Exception ex)
@@ -137,7 +218,8 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
     /// <summary>
     /// Dispatch to Grain handlers (Orleans/ProtoActor actors)
     /// </summary>
-    private async Task<bool> TryDispatchToGrainHandlersAsync(string streamId, EventEnvelope envelope)
+    private async Task<bool> TryDispatchToGrainHandlersAsync(
+        string streamId, EventEnvelope envelope)
     {
         foreach (var handler in _eventHandlers)
         {
@@ -146,15 +228,17 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
                 var handled = await handler.HandleEventAsync(streamId, envelope);
                 if (handled)
                 {
-                    _logger.LogDebug("Event {EventId} handled by {HandlerType} for StreamId {StreamId}", 
-                        envelope.Id, handler.GetType().Name, streamId);
+                    _logger.LogInformation(
+                        "Message dispatched - StreamId={StreamId}, Handler={HandlerType}", 
+                        streamId, handler.GetType().Name);
                     return true;
                 }
             }
             catch (System.Exception ex)
             {
-                _logger.LogWarning(ex, "Event handler {HandlerType} failed for StreamId {StreamId}", 
-                    handler.GetType().Name, streamId);
+                _logger.LogWarning(ex,
+                    "Handler failed - StreamId={StreamId}, Handler={HandlerType}", 
+                    streamId, handler.GetType().Name);
             }
         }
         
@@ -164,9 +248,10 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
     /// <summary>
     /// Try stream not found handlers (activate actor) and retry dispatch
     /// </summary>
-    private async Task<bool> TryActivateAndRetryAsync(string streamId, EventEnvelope envelope)
+    private async Task<bool> TryActivateAndRetryAsync(
+        string streamId, EventEnvelope envelope)
     {
-        _logger.LogDebug("No event handler found for StreamId {StreamId}, trying activation handlers...", streamId);
+        _logger.LogDebug("Trying activation for StreamId={StreamId}", streamId);
         
         foreach (var notFoundHandler in _notFoundHandlers)
         {
@@ -176,7 +261,7 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
             }
             catch (System.Exception ex)
             {
-                _logger.LogError(ex, "StreamNotFoundHandler failed for StreamId {StreamId}", streamId);
+                _logger.LogError(ex, "Activation failed - StreamId={StreamId}", streamId);
             }
         }
         
@@ -188,15 +273,15 @@ public class StreamMessageDispatcher : IConsumer<ByteArrayMessage>
                 var handled = await handler.HandleEventAsync(streamId, envelope);
                 if (handled)
                 {
-                    _logger.LogDebug("Event {EventId} handled after activation for StreamId {StreamId}", 
-                        envelope.Id, streamId);
+                    _logger.LogInformation(
+                        "Message dispatched (after activation) - StreamId={StreamId}", streamId);
                     return true;
                 }
             }
             catch (System.Exception ex)
             {
-                _logger.LogWarning(ex, "Event handler failed after activation for StreamId {StreamId}", 
-                    handler.GetType().Name);
+                _logger.LogWarning(ex,
+                    "Handler failed (after activation) - StreamId={StreamId}", streamId);
             }
         }
         

--- a/src/Aevatar.Agents.Abstractions/Extensions/RpcProxy.cs
+++ b/src/Aevatar.Agents.Abstractions/Extensions/RpcProxy.cs
@@ -166,10 +166,17 @@ internal class RpcProxy<TInterface> : DispatchProxy where TInterface : class
         foreach (var arg in args ?? [])
             request.Args.Add(ProtobufPacker.Pack(arg));
 
+        // Check if method is marked as read-only (safe for concurrent execution):
+        // - [ReadOnlyRpc] - our framework attribute (recommended)
+        // - [ReadOnly] - Orleans attribute (for compatibility with existing code)
+        var isReadOnlyRpc = targetMethod.GetCustomAttributes(true)
+            .Any(attr => attr.GetType().Name == "ReadOnlyRpcAttribute" 
+                      || attr.GetType().Name == "ReadOnlyAttribute");
+
         var returnType = targetMethod.ReturnType;
 
         if (returnType == typeof(Task))
-            return InvokeVoidAsync(request);
+            return InvokeVoidAsync(request, isReadOnlyRpc);
 
         if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
         {
@@ -179,16 +186,19 @@ internal class RpcProxy<TInterface> : DispatchProxy where TInterface : class
                 .First(m => m.Name == nameof(InvokeAsync) && m.IsGenericMethod);
             return invokeMethod
                 .MakeGenericMethod(resultType)
-                .Invoke(this, [request]);
+                .Invoke(this, [request, isReadOnlyRpc]);
         }
 
         throw new NotSupportedException(
             $"Return type '{returnType.Name}' not supported. Use Task or Task<T>.");
     }
 
-    private async Task InvokeVoidAsync(RpcRequest request)
+    private async Task InvokeVoidAsync(RpcRequest request, bool isReadOnlyRpc)
     {
-        var responseBytes = await _actor.InvokeRpcAsync(request.ToByteArray());
+        var requestBytes = request.ToByteArray();
+        var responseBytes = isReadOnlyRpc 
+            ? await _actor.InvokeReadOnlyRpcAsync(requestBytes)
+            : await _actor.InvokeRpcAsync(requestBytes);
         var response = RpcResponse.Parser.ParseFrom(responseBytes);
 
         if (!response.Success)
@@ -196,14 +206,21 @@ internal class RpcProxy<TInterface> : DispatchProxy where TInterface : class
                 $"RPC call '{request.MethodName}' failed: {response.Error?.Message ?? "Unknown error"}");
     }
 
-    private async Task<TResult> InvokeAsync<TResult>(RpcRequest request)
+    private async Task<TResult> InvokeAsync<TResult>(RpcRequest request, bool isReadOnlyRpc)
     {
-        var responseBytes = await _actor.InvokeRpcAsync(request.ToByteArray());
+        var requestBytes = request.ToByteArray();
+        var responseBytes = isReadOnlyRpc 
+            ? await _actor.InvokeReadOnlyRpcAsync(requestBytes)
+            : await _actor.InvokeRpcAsync(requestBytes);
         var response = RpcResponse.Parser.ParseFrom(responseBytes);
 
         if (!response.Success)
             throw new InvalidOperationException(
                 $"RPC call '{request.MethodName}' failed: {response.Error?.Message ?? "Unknown error"}");
+
+        // Handle null result (should be packed as Empty, but check for safety)
+        if (response.Result == null)
+            return default(TResult)!;
 
         return ProtobufPacker.Unpack<TResult>(response.Result);
     }

--- a/src/Aevatar.Agents.Abstractions/IGAgentActor.cs
+++ b/src/Aevatar.Agents.Abstractions/IGAgentActor.cs
@@ -67,11 +67,21 @@ public interface IGAgentActor : IEventPublisher
     Task DeactivateAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Invoke RPC method on Agent via Protobuf.
+    /// Invoke RPC method on Agent via Protobuf (for write operations).
     /// For Local runtime, this may directly call the method.
-    /// For Orleans runtime, this calls the Grain RPC method.
+    /// For Orleans runtime, this calls the Grain RPC method (serial execution).
     /// </summary>
     /// <param name="requestBytes">RpcRequest serialized bytes</param>
     /// <returns>RpcResponse serialized bytes</returns>
     Task<byte[]> InvokeRpcAsync(byte[] requestBytes);
+    
+    /// <summary>
+    /// Invoke read-only RPC method on Agent via Protobuf.
+    /// For Local runtime, same as InvokeRpcAsync.
+    /// For Orleans runtime, this calls the [AlwaysInterleave] Grain method (concurrent execution).
+    /// Use this for methods marked with [ReadOnly] attribute.
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes);
 }

--- a/src/Aevatar.Agents.Abstractions/ReadOnlyRpcAttribute.cs
+++ b/src/Aevatar.Agents.Abstractions/ReadOnlyRpcAttribute.cs
@@ -1,0 +1,19 @@
+namespace Aevatar.Agents.Abstractions;
+
+/// <summary>
+/// Marks a RPC method as read-only (does not modify Agent state).
+/// When used on interface methods, RpcProxy will route calls through
+/// InvokeReadOnlyRpcAsync which has [AlwaysInterleave] on Orleans Grain,
+/// allowing concurrent execution without blocking on other operations.
+/// 
+/// Use this for query/get operations that only read Agent state.
+/// 
+/// Note: This is NOT Orleans' [ReadOnly] attribute. Orleans' [ReadOnly] only works
+/// on Grain implementation methods. Since our RPC mechanism goes through a single
+/// InvokeRpcAsync entry point, Orleans cannot see the business method's attributes.
+/// This attribute enables our framework to make the routing decision at RPC level.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class ReadOnlyRpcAttribute : Attribute
+{
+}

--- a/src/Aevatar.Agents.Abstractions/Rpc/ProtobufPacker.cs
+++ b/src/Aevatar.Agents.Abstractions/Rpc/ProtobufPacker.cs
@@ -71,6 +71,10 @@ public static class ProtobufPacker
     /// </summary>
     public static object? Unpack(Any any, System.Type targetType)
     {
+        // Handle null Any (should be treated as null/Empty)
+        if (any == null || string.IsNullOrEmpty(any.TypeUrl))
+            return null;
+
         var underlyingType = Nullable.GetUnderlyingType(targetType);
         var actualType = underlyingType ?? targetType;
 

--- a/src/Aevatar.Agents.Core/EventSourcing/EventSourcingOptions.cs
+++ b/src/Aevatar.Agents.Core/EventSourcing/EventSourcingOptions.cs
@@ -1,0 +1,33 @@
+namespace Aevatar.Agents.Core.EventSourcing;
+
+/// <summary>
+/// Configuration options for EventSourcing.
+/// Maps to appsettings.json section "EventSourcing".
+/// </summary>
+public class EventSourcingOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json
+    /// </summary>
+    public const string SectionName = "EventSourcing";
+
+    /// <summary>
+    /// Enable or disable EventSourcing.
+    /// When disabled, agents use simple StateStore persistence instead.
+    /// Default: true
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Number of events between automatic snapshots.
+    /// Default: 10
+    /// </summary>
+    public int SnapshotFrequency { get; set; } = 10;
+
+    /// <summary>
+    /// EventStore provider type.
+    /// Supported: "Memory", "MongoDB", "Orleans"
+    /// Default: "MongoDB"
+    /// </summary>
+    public string Provider { get; set; } = "MongoDB";
+}

--- a/src/Aevatar.Agents.Core/EventSourcing/ProtobufEventTypeResolver.cs
+++ b/src/Aevatar.Agents.Core/EventSourcing/ProtobufEventTypeResolver.cs
@@ -8,12 +8,13 @@ namespace Aevatar.Agents.Core.EventSourcing;
 
 /// <summary>
 /// Resolves Protobuf event types using reflection and caching.
+/// Supports cross-assembly lookup for multi-module deployments.
 /// </summary>
 public class ProtobufEventTypeResolver : IEventTypeResolver
 {
     private readonly ILogger<ProtobufEventTypeResolver>? _logger;
     
-    // Key: Simple type name (e.g., "MoneyDeposited")
+    // Key: Protobuf full type name (e.g., "aevatar.agents.banking.MoneyDeposited")
     // Value: Cached parser and metadata
     private readonly ConcurrentDictionary<string, EventTypeInfo> _typeCache = new();
 
@@ -27,7 +28,7 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
         var fullTypeName = ExtractFullTypeName(typeUrl);
         var simpleTypeName = ExtractSimpleTypeName(fullTypeName);
 
-        // Fast path: cache hit
+        // Fast path: cache hit by full protobuf name
         if (_typeCache.TryGetValue(fullTypeName, out var info))
         {
             return info;
@@ -38,29 +39,34 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
         if (info != null)
         {
             _typeCache[fullTypeName] = info;
-            _logger?.LogInformation("Type {TypeName} cached. Total cached types: {Count}", fullTypeName, _typeCache.Count);
+            _logger?.LogInformation(
+                "Type {TypeName} cached. Total cached types: {Count}",
+                fullTypeName, _typeCache.Count);
         }
 
         return info;
     }
 
-    private EventTypeInfo? BuildTypeCache(string fullTypeName, string simpleTypeName, Assembly assembly)
+    private EventTypeInfo? BuildTypeCache(
+        string fullTypeName,
+        string simpleTypeName,
+        Assembly searchAssembly)
     {
         try
         {
-            // 1) Prefer exact Protobuf full-name match via static Descriptor.FullName.
-            var matchingType = FindMessageTypeByDescriptorFullName(assembly, fullTypeName)
-                               ?? FindMessageTypeBySimpleName(assembly, simpleTypeName);
+            // 1) Try searchAssembly first (fast path for single-assembly scenarios)
+            var matchingType = FindMessageTypeByDescriptorFullName(searchAssembly, fullTypeName)
+                               ?? FindMessageTypeBySimpleName(searchAssembly, simpleTypeName);
 
-            // 2) Fallback: scan all loaded assemblies (cross-boundary events often live in different modules).
+            // 2) Fallback: scan all loaded assemblies (cross-module events)
             if (matchingType == null)
             {
-                foreach (var a in AppDomain.CurrentDomain.GetAssemblies()
-                             .Where(x => !x.IsDynamic)
-                             .OrderBy(x => x.FullName, StringComparer.Ordinal))
+                foreach (var asm in AppDomain.CurrentDomain.GetAssemblies()
+                             .Where(a => !a.IsDynamic)
+                             .OrderBy(a => a.FullName, StringComparer.Ordinal))
                 {
-                    matchingType = FindMessageTypeByDescriptorFullName(a, fullTypeName)
-                                   ?? FindMessageTypeBySimpleName(a, simpleTypeName);
+                    matchingType = FindMessageTypeByDescriptorFullName(asm, fullTypeName)
+                                   ?? FindMessageTypeBySimpleName(asm, simpleTypeName);
                     if (matchingType != null)
                         break;
                 }
@@ -69,8 +75,8 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
             if (matchingType == null)
             {
                 _logger?.LogWarning(
-                    "Type {TypeName} not found (TypeUrl fullName: {FullTypeName}) starting from assembly {Assembly}",
-                    simpleTypeName, fullTypeName, assembly.FullName);
+                    "Type {TypeName} not found (fullName: {FullTypeName}) starting from assembly {Assembly}",
+                    simpleTypeName, fullTypeName, searchAssembly.FullName);
                 return null;
             }
 
@@ -80,11 +86,15 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
 
             if (parser == null)
             {
-                _logger?.LogWarning("Parser property not found for type {TypeName}", matchingType.FullName);
+                _logger?.LogWarning(
+                    "Parser property not found for type {TypeName}",
+                    matchingType.FullName);
                 return null;
             }
 
-            _logger?.LogDebug("Built type cache for {TypeName} (type: {FullName})", simpleTypeName, matchingType.FullName);
+            _logger?.LogDebug(
+                "Built type cache for {TypeName} (type: {FullName})",
+                simpleTypeName, matchingType.FullName);
 
             return new EventTypeInfo(matchingType, parser);
         }
@@ -95,6 +105,11 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
         }
     }
 
+    /// <summary>
+    /// Extract full protobuf type name from typeUrl.
+    /// e.g., "type.googleapis.com/aevatar.agents.banking.MoneyDeposited"
+    ///     -> "aevatar.agents.banking.MoneyDeposited"
+    /// </summary>
     private static string ExtractFullTypeName(string typeUrl)
     {
         if (string.IsNullOrWhiteSpace(typeUrl))
@@ -105,6 +120,10 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
             : typeUrl.Trim();
     }
 
+    /// <summary>
+    /// Extract simple C# type name from protobuf full name.
+    /// e.g., "aevatar.agents.banking.MoneyDeposited" -> "MoneyDeposited"
+    /// </summary>
     private static string ExtractSimpleTypeName(string fullTypeName)
     {
         if (string.IsNullOrWhiteSpace(fullTypeName))
@@ -114,6 +133,9 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
             : fullTypeName;
     }
 
+    /// <summary>
+    /// Exact match by Protobuf Descriptor.FullName (handles package-qualified names).
+    /// </summary>
     private static Type? FindMessageTypeByDescriptorFullName(Assembly assembly, string fullTypeName)
     {
         if (string.IsNullOrWhiteSpace(fullTypeName))
@@ -134,12 +156,15 @@ public class ProtobufEventTypeResolver : IEventTypeResolver
         }
         catch
         {
-            // best-effort: some assemblies may throw on GetTypes()
+            // Best-effort: some assemblies may throw on GetTypes()
         }
 
         return null;
     }
 
+    /// <summary>
+    /// Fallback match by simple C# class name.
+    /// </summary>
     private static Type? FindMessageTypeBySimpleName(Assembly assembly, string simpleTypeName)
     {
         if (string.IsNullOrWhiteSpace(simpleTypeName))

--- a/src/Aevatar.Agents.Core/EventSourcing/ReflectionEventHandlerDiscoverer.cs
+++ b/src/Aevatar.Agents.Core/EventSourcing/ReflectionEventHandlerDiscoverer.cs
@@ -7,41 +7,46 @@ namespace Aevatar.Agents.Core.EventSourcing;
 
 /// <summary>
 /// Default implementation of IEventHandlerDiscoverer using reflection.
+/// Walks the inheritance chain with DeclaredOnly to ensure proper deduplication
+/// when derived classes override or hide base handlers.
 /// </summary>
 public class ReflectionEventHandlerDiscoverer : IEventHandlerDiscoverer
 {
     public MethodInfo[] DiscoverEventHandlers(Type type)
     {
-        var selected = new Dictionary<MethodInfo, MethodInfo>();
+        // Collect unique handlers by walking the inheritance chain bottom-up.
+        // This ensures that if a derived class overrides or hides a base handler,
+        // only the most-derived version is included.
+        var seen = new HashSet<MethodInfo>(MethodBaseDefinitionComparer.Instance);
+        var handlers = new List<(MethodInfo Method, int Priority)>();
+
         var current = type;
-
-        while (current != null)
+        while (current != null && current != typeof(object))
         {
-            var methods = current.GetMethods(
-                BindingFlags.Instance |
-                BindingFlags.Public |
-                BindingFlags.NonPublic |
-                BindingFlags.DeclaredOnly);
+            var declaredMethods = current.GetMethods(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.DeclaredOnly);
 
-            foreach (var method in methods)
+            foreach (var method in declaredMethods)
             {
-                if (!IsEventHandlerMethod(method))
-                    continue;
+                if (!IsEventHandlerMethod(method)) continue;
 
-                var baseDefinition = method.GetBaseDefinition();
-                if (selected.ContainsKey(baseDefinition))
-                    continue;
+                // Dedup: only keep the most-derived version
+                if (!seen.Add(method)) continue;
 
-                selected[baseDefinition] = method;
+                var priority = method.GetCustomAttribute<EventHandlerAttribute>()?.Priority
+                               ?? method.GetCustomAttribute<AllEventHandlerAttribute>()?.Priority
+                               ?? int.MaxValue;
+
+                handlers.Add((method, priority));
             }
 
             current = current.BaseType;
         }
 
-        return selected.Values
-            .OrderBy(m => m.GetCustomAttribute<EventHandlerAttribute>()?.Priority ??
-                          m.GetCustomAttribute<AllEventHandlerAttribute>()?.Priority ??
-                          int.MaxValue)
+        return handlers
+            .OrderBy(h => h.Priority)
+            .Select(h => h.Method)
             .ToArray();
     }
 
@@ -67,12 +72,31 @@ public class ReflectionEventHandlerDiscoverer : IEventHandlerDiscoverer
             return paramType == typeof(EventEnvelope);
         }
 
-        // Convention-based handlers: method named HandleAsync or HandleEventAsync, parameter is IMessage
+        // Convention-based handlers: HandleAsync or HandleEventAsync
         if (method.Name is "HandleAsync" or "HandleEventAsync")
         {
             return typeof(IMessage).IsAssignableFrom(paramType) && !paramType.IsAbstract;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Comparer that treats two MethodInfo instances as equal
+    /// if they resolve to the same base definition (virtual slot).
+    /// </summary>
+    private sealed class MethodBaseDefinitionComparer : IEqualityComparer<MethodInfo>
+    {
+        public static readonly MethodBaseDefinitionComparer Instance = new();
+
+        public bool Equals(MethodInfo? x, MethodInfo? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+            return x.GetBaseDefinition().Equals(y.GetBaseDefinition());
+        }
+
+        public int GetHashCode(MethodInfo obj)
+            => obj.GetBaseDefinition().GetHashCode();
     }
 }

--- a/src/Aevatar.Agents.Core/GAgentActorBase.cs
+++ b/src/Aevatar.Agents.Core/GAgentActorBase.cs
@@ -593,6 +593,16 @@ public abstract class GAgentActorBase : IGAgentActor, IActorHierarchyOperations
 
         return RpcInvoker.InvokeAsync(Agent, requestBytes, Logger, CancellationToken.None);
     }
+    
+    /// <summary>
+    /// Invoke read-only RPC method.
+    /// For Local runtime, this is the same as InvokeRpcAsync (no concurrent control).
+    /// </summary>
+    public virtual Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes)
+    {
+        // Local runtime: no difference between read/write RPC
+        return InvokeRpcAsync(requestBytes);
+    }
 
     private bool TryGetRunBinding(EventEnvelope envelope, out string scopeId, out string runId)
     {

--- a/src/Aevatar.Agents.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Agents.Core/GAgentBase.TState.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Aevatar.Agents.Abstractions;
@@ -116,6 +116,11 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
     /// </summary>
     protected IEventStore? EventStore { get; set; }
 
+    /// <summary>
+    /// EventSourcing options (injected from configuration)
+    /// </summary>
+    protected EventSourcingOptions? EventSourcingOptions { get; set; }
+
     private long _currentVersion;
 
     // Batch event management
@@ -138,9 +143,9 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
         // StateProjector is injected by StateProjectorInjector after agent creation
         
         // State initialization strategy:
-        // - If EventStore is configured: replay events (may or may not activate event sourcing)
-        // - If event sourcing is not active (version==0), fall back to StateStore
-        // This avoids blocking StateStore just because EventStore is injected.
+        // - If EventStore is configured: Use Event Sourcing (replay events from snapshot)
+        // - Otherwise: Use StateStore for simple state persistence
+        // These two strategies are mutually exclusive to avoid duplication
         
         if (EventStore != null)
         {
@@ -148,8 +153,7 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
             // No need for StateStore - EventStore handles all persistence
             await ReplayEventsAsync(ct);
         }
-
-        if (_currentVersion == 0 && StateStore != null)
+        else if (StateStore != null)
         {
             // Simple state mode: Load state directly from StateStore
             // Only load if there's persisted state, otherwise keep current state
@@ -182,14 +186,12 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
     /// </summary>
     public override async Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
     {
-        // Persistence strategy:
-        // - EventStore may be injected but event sourcing is active only when version > 0.
-        // - StateStore should not be blocked until event sourcing actually starts.
-        var eventStoreEnabled = EventStore != null;
-        var eventSourcingActive = eventStoreEnabled && _currentVersion > 0;
+        // Persistence strategy: EventStore and StateStore are mutually exclusive
+        // to avoid duplicate storage operations
+        var useEventSourcing = EventStore != null;
         
-        // 1. Load State (only when event sourcing is not active)
-        if (!eventSourcingActive && StateStore != null)
+        // 1. Load State (only in StateStore mode - EventStore mode uses in-memory state from replay)
+        if (!useEventSourcing && StateStore != null)
         {
             using (StateProtectionContext.BeginEventHandlerScope())
             {
@@ -206,16 +208,16 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
         await HandleEventCoreAsync(envelope, ct);
 
         // 3. Persist state changes
-        if (eventStoreEnabled)
+        if (useEventSourcing)
         {
-            // Event Sourcing mode: Persist via events + snapshots (best-effort).
-            // Pass notifyStateChanged=false to avoid duplicate call (we call it below).
+            // Event Sourcing mode: Persist via events + snapshots
+            // EventStore handles all persistence, no StateStore needed
+            // Pass notifyStateChanged=false to avoid duplicate call (we call it below)
             await ConfirmEventsAsync(ct, notifyStateChanged: false);
         }
-
-        if (StateStore != null && _currentVersion == 0)
+        else if (StateStore != null)
         {
-            // StateStore mode (event sourcing not active): Direct state persistence.
+            // StateStore mode: Direct state persistence
             await StateStore.SaveAsync(Id, _state, ct);
         }
 
@@ -559,9 +561,8 @@ public abstract class GAgentBase<TState> : GAgentBase, IStateGAgent<TState>
 
     // ============ Snapshot Operations ============
 
-    // TODO: Read from configuration (EventSourcing:SnapshotFrequency)
     protected virtual ISnapshotStrategy SnapshotStrategy =>
-        new IntervalSnapshotStrategy(100);
+        new IntervalSnapshotStrategy(EventSourcingOptions?.SnapshotFrequency ?? 10);
 
     /// <summary>
     /// Create snapshot using StateStore (preferred) or EventStore (fallback)

--- a/src/Aevatar.Agents.Core/Helpers/EventSourcingOptionsInjector.cs
+++ b/src/Aevatar.Agents.Core/Helpers/EventSourcingOptionsInjector.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using Aevatar.Agents.Abstractions;
+using Aevatar.Agents.Core.EventSourcing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Agents.Core.Helpers;
+
+/// <summary>
+/// Injects EventSourcingOptions into Agent instances
+/// </summary>
+public static class EventSourcingOptionsInjector
+{
+    /// <summary>
+    /// Inject EventSourcingOptions into Agent
+    /// </summary>
+    public static void InjectEventSourcingOptions(IGAgent agent, IServiceProvider serviceProvider)
+    {
+        if (agent == null || serviceProvider == null)
+            return;
+
+        var options = serviceProvider.GetService<IOptions<EventSourcingOptions>>()?.Value;
+        if (options == null)
+            return;
+
+        var agentType = agent.GetType();
+        var property = FindEventSourcingOptionsProperty(agentType);
+        
+        if (property != null && property.CanWrite)
+        {
+            try
+            {
+                property.SetValue(agent, options);
+            }
+            catch
+            {
+                // Silently ignore injection failures
+            }
+        }
+    }
+
+    private static PropertyInfo? FindEventSourcingOptionsProperty(Type agentType)
+    {
+        const BindingFlags bindingFlags =
+            BindingFlags.Instance |
+            BindingFlags.Public |
+            BindingFlags.NonPublic;
+
+        var type = agentType;
+        while (type != null && type != typeof(object))
+        {
+            var property = type.GetProperty("EventSourcingOptions", bindingFlags);
+            if (property != null && property.PropertyType == typeof(EventSourcingOptions))
+            {
+                return property;
+            }
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+}
+

--- a/src/Aevatar.Agents.Core/Rpc/RpcInvoker.cs
+++ b/src/Aevatar.Agents.Core/Rpc/RpcInvoker.cs
@@ -6,7 +6,6 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 using System.Reflection;
-using System.Threading;
 
 namespace Aevatar.Agents.Core.Rpc;
 
@@ -20,11 +19,7 @@ public static class RpcInvoker
     /// <summary>
     /// Invoke RPC method on Agent
     /// </summary>
-    public static async Task<byte[]> InvokeAsync(
-        IGAgent agent,
-        byte[] requestBytes,
-        ILogger? logger = null,
-        CancellationToken ct = default)
+    public static async Task<byte[]> InvokeAsync(IGAgent agent, byte[] requestBytes, ILogger? logger = null, CancellationToken ct = default)
     {
         var request = RpcRequest.Parser.ParseFrom(requestBytes);
         var response = new RpcResponse
@@ -33,10 +28,17 @@ public static class RpcInvoker
             Success = false
         };
 
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var agentId = agent?.Id ?? "unknown";
+        var agentType = agent?.GetType().Name ?? "unknown";
+        
         try
         {
             if (agent == null)
                 throw new InvalidOperationException("Agent not initialized");
+
+            logger?.LogDebug("[PERF][RPC] Starting {Method} on {AgentId} ({AgentType})", 
+                request.MethodName, agentId, agentType);
 
             // Pass argument count to select correct method overload
             var method = GetCachedMethod(agent.GetType(), request.MethodName, request.Args.Count);
@@ -50,14 +52,26 @@ public static class RpcInvoker
                 result = GetTaskResult(task);
             }
 
-            if (result != null)
-            {
-                response.Result = ProtobufPacker.Pack(result);
-            }
+            // Always pack result (even if null, it will be packed as Empty)
+            response.Result = ProtobufPacker.Pack(result);
             response.Success = true;
+            
+            stopwatch.Stop();
+            // Log warning if RPC takes more than 1 second
+            if (stopwatch.ElapsedMilliseconds > 1000)
+            {
+                logger?.LogWarning("[PERF][RPC] ⚠️ SLOW: {Method} on {AgentId} ({AgentType}) took {Duration}ms", 
+                    request.MethodName, agentId, agentType, stopwatch.ElapsedMilliseconds);
+            }
+            else
+            {
+                logger?.LogDebug("[PERF][RPC] Completed {Method} on {AgentId}: {Duration}ms", 
+                    request.MethodName, agentId, stopwatch.ElapsedMilliseconds);
+            }
         }
         catch (Exception ex)
         {
+            stopwatch.Stop();
             var innerEx = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
             response.Error = new RpcError
             {
@@ -65,7 +79,8 @@ public static class RpcInvoker
                 Message = innerEx.Message,
                 StackTrace = innerEx.StackTrace ?? string.Empty
             };
-            logger?.LogError(innerEx, "RPC method {Method} failed", request.MethodName);
+            logger?.LogError(innerEx, "[PERF][RPC] ❌ {Method} on {AgentId} failed after {Duration}ms: {Error}", 
+                request.MethodName, agentId, stopwatch.ElapsedMilliseconds, innerEx.Message);
         }
 
         return response.ToByteArray();
@@ -87,7 +102,9 @@ public static class RpcInvoker
                 throw new InvalidOperationException($"Method '{k.Item2}' not found on type '{k.Item1.Name}'");
             }
 
-            // Select method based on argument count
+            // Select method based on argument count.
+            // CancellationToken parameters are injected by the framework (not sent by client),
+            // so exclude them from the effective parameter count when matching.
             MethodInfo? method = null;
             if (methods.Count == 1)
             {
@@ -95,14 +112,21 @@ public static class RpcInvoker
             }
             else
             {
-                // Multiple overloads - find the one matching argument count
-                method = methods.FirstOrDefault(m => m.GetParameters().Length == k.Item3);
+                // Multiple overloads - match by effective param count (excluding CancellationToken)
+                method = methods.FirstOrDefault(m =>
+                    CountEffectiveParams(m) == k.Item3);
                 if (method == null)
                 {
-                    // If no exact match, try to find method with optional parameters
+                    // Fallback: optional parameters
                     method = methods
-                        .Where(m => m.GetParameters().Count(p => !p.HasDefaultValue) <= k.Item3
-                                    && m.GetParameters().Length >= k.Item3)
+                        .Where(m =>
+                        {
+                            var nonCt = m.GetParameters()
+                                .Where(p => p.ParameterType != typeof(CancellationToken));
+                            var requiredCount = nonCt.Count(p => !p.HasDefaultValue);
+                            var totalCount = nonCt.Count();
+                            return requiredCount <= k.Item3 && totalCount >= k.Item3;
+                        })
                         .FirstOrDefault();
                 }
             }
@@ -130,27 +154,48 @@ public static class RpcInvoker
         });
     }
 
+    /// <summary>
+    /// Count parameters excluding CancellationToken (which is framework-injected, not client-supplied).
+    /// </summary>
+    private static int CountEffectiveParams(MethodInfo method)
+    {
+        return method.GetParameters().Count(p => p.ParameterType != typeof(CancellationToken));
+    }
+
+    /// <summary>
+    /// Deserialize protobuf args into method parameters.
+    /// CancellationToken parameters are automatically injected from the provided <paramref name="ct"/>,
+    /// since they cannot be serialized over the wire.
+    /// </summary>
     private static object?[] DeserializeArgs(
         Google.Protobuf.Collections.RepeatedField<Any> protoArgs,
         ParameterInfo[] paramInfos,
-        CancellationToken ct)
+        CancellationToken ct = default)
     {
-        return paramInfos.Select((p, i) =>
+        var args = new object?[paramInfos.Length];
+        var protoIdx = 0;
+
+        for (var i = 0; i < paramInfos.Length; i++)
         {
-            // Special-case: CancellationToken is not serialized via protobuf args.
-            // If the method signature includes CancellationToken (often optional), inject the provided ct.
+            var p = paramInfos[i];
+
             if (p.ParameterType == typeof(CancellationToken))
             {
-                return ct;
+                // Framework-injected: propagate the caller's CancellationToken
+                args[i] = ct;
             }
-
-            if (i < protoArgs.Count)
+            else if (protoIdx < protoArgs.Count)
             {
-                return ProtobufPacker.Unpack(protoArgs[i], p.ParameterType);
+                args[i] = ProtobufPacker.Unpack(protoArgs[protoIdx], p.ParameterType);
+                protoIdx++;
             }
+            else
+            {
+                args[i] = p.HasDefaultValue ? p.DefaultValue : null;
+            }
+        }
 
-            return p.HasDefaultValue ? p.DefaultValue : null;
-        }).ToArray();
+        return args;
     }
 
     private static object? GetTaskResult(Task task)

--- a/src/Aevatar.Agents.Runtime.Orleans/Aevatar.Agents.Runtime.Orleans.csproj
+++ b/src/Aevatar.Agents.Runtime.Orleans/Aevatar.Agents.Runtime.Orleans.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -28,6 +28,7 @@
   </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>

--- a/src/Aevatar.Agents.Runtime.Orleans/EventSourcing/OrleansEventStore.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/EventSourcing/OrleansEventStore.cs
@@ -48,11 +48,23 @@ public class OrleansEventStore : IEventStore
         var currentVersion = await _eventRepository.GetLatestVersionAsync(agentId, agentTypeName, ct);
         if (currentVersion != expectedVersion)
         {
-            _logger.LogWarning(
-                "Version conflict for agent {AgentId}: expected {ExpectedVersion}, got {CurrentVersion}",
-                agentId, expectedVersion, currentVersion);
-            throw new InvalidOperationException(
-                $"Concurrency conflict: expected version {expectedVersion}, got {currentVersion}");
+            // Special case: Migration scenario - snapshot exists (expectedVersion > 0) but event stream is empty (currentVersion == 0)
+            // This is normal after data migration where only snapshots are imported without event history
+            if (currentVersion == 0 && expectedVersion > 0)
+            {
+                _logger.LogInformation(
+                    "Migration scenario detected for agent {AgentId}: snapshot version {SnapshotVersion}, event stream empty. Allowing append.",
+                    agentId, expectedVersion);
+                // Continue execution - this is expected after migration
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Version conflict for agent {AgentId}: expected {ExpectedVersion}, got {CurrentVersion}",
+                    agentId, expectedVersion, currentVersion);
+                throw new InvalidOperationException(
+                    $"Concurrency conflict: expected version {expectedVersion}, got {currentVersion}");
+            }
         }
 
         // Direct repository call - no extra Grain RPC

--- a/src/Aevatar.Agents.Runtime.Orleans/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,9 @@ using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.AI.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans;
 
 namespace Aevatar.Agents.Runtime.Orleans.Extensions;
 
@@ -14,7 +17,36 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAevatarOrleansRuntime(this IServiceCollection services)
     {
         // Core Orleans runtime services
-        services.AddSingleton<IGAgentActorFactory, OrleansGAgentActorFactory>();
+        // Use a factory method to choose the correct implementation based on context:
+        // - In Silo (IGrainFactory available): Use SiloGAgentActorFactory for Grain-to-Grain calls
+        // - In Client (only IClusterClient): Use OrleansGAgentActorFactory for remote calls
+        services.AddSingleton<IGAgentActorFactory>(sp =>
+        {
+            var grainFactory = sp.GetService<IGrainFactory>();
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            
+            if (grainFactory != null)
+            {
+                // Running in Silo - use SiloGAgentActorFactory for internal Grain-to-Grain calls
+                return new SiloGAgentActorFactory(
+                    grainFactory,
+                    loggerFactory.CreateLogger<SiloGAgentActorFactory>());
+            }
+            else
+            {
+                // Running in Client - use OrleansGAgentActorFactory for remote calls
+                var clusterClient = sp.GetRequiredService<IClusterClient>();
+                var messageStreamProvider = sp.GetService<IMessageStreamProvider>();
+                var providerOptions = sp.GetService<IOptions<MessageStreamProviderOptions>>();
+                return new OrleansGAgentActorFactory(
+                    sp,
+                    clusterClient,
+                    loggerFactory.CreateLogger<OrleansGAgentActorFactory>(),
+                    messageStreamProvider,
+                    providerOptions);
+            }
+        });
+        
         services.AddSingleton<IGAgentActorManager, OrleansGAgentActorManager>();
         services.TryAddSingleton<IGAgentFactory, AIGAgentFactory>();
         

--- a/src/Aevatar.Agents.Runtime.Orleans/IGAgentGrain.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/IGAgentGrain.cs
@@ -46,6 +46,29 @@ public interface IGAgentGrain : IGrainWithStringKey
     Task HandleEventAsync(byte[] envelopeBytes);
 
     /// <summary>
+    /// Publish event by envelope bytes (non-blocking, via Stream).
+    /// Used by Silo-internal actor to keep a single IGAgentActor API surface.
+    /// </summary>
+    /// <param name="envelopeBytes">EventEnvelope serialized bytes</param>
+    /// <param name="direction">Propagation direction</param>
+    /// <param name="isInternalCall">
+    /// If true, keeps PublisherId for self-handling check; if false, clears PublisherId so Agent can handle the event.
+    /// </param>
+    /// <returns>Event ID</returns>
+    Task<string> PublishEventAsync(byte[] envelopeBytes, EventDirection direction = EventDirection.Down, bool isInternalCall = false);
+
+    /// <summary>
+    /// Point-to-point send by envelope bytes (non-blocking, via Stream).
+    /// Used by Silo-internal actor to keep a single IGAgentActor API surface.
+    /// </summary>
+    /// <param name="targetAgentId">Target agent id (full ActorId)</param>
+    /// <param name="envelopeBytes">EventEnvelope serialized bytes</param>
+    /// <param name="onArrivalDirection">Propagation direction after arrival</param>
+    /// <param name="isInternalCall">Same semantics as PublishEventAsync</param>
+    /// <returns>Event ID</returns>
+    Task<string> SendToAsync(string targetAgentId, byte[] envelopeBytes, EventDirection onArrivalDirection = EventDirection.Unspecified, bool isInternalCall = false);
+
+    /// <summary>
     /// Add child Agent
     /// </summary>
     Task AddChildAsync(string childId);
@@ -90,4 +113,14 @@ public interface IGAgentGrain : IGrainWithStringKey
     /// <param name="requestBytes">RpcRequest serialized bytes</param>
     /// <returns>RpcResponse serialized bytes</returns>
     Task<byte[]> InvokeRpcAsync(byte[] requestBytes);
+    
+    /// <summary>
+    /// Protobuf RPC method invocation (for read-only operations)
+    /// [AlwaysInterleave] allows concurrent execution - safe for read-only operations
+    /// Use this for methods marked with [ReadOnly] attribute
+    /// </summary>
+    /// <param name="requestBytes">RpcRequest serialized bytes</param>
+    /// <returns>RpcResponse serialized bytes</returns>
+    [AlwaysInterleave]
+    Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes);
 }

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActor.cs
@@ -406,5 +406,14 @@ public class OrleansGAgentActor : IGAgentActor, IActorHierarchyOperations
         return await _grain!.InvokeRpcAsync(requestBytes);
     }
 
+    /// <summary>
+    /// Invoke read-only RPC method (uses [AlwaysInterleave] for concurrent execution)
+    /// </summary>
+    public async Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes)
+    {
+        EnsureGrain();
+        return await _grain!.InvokeReadOnlyRpcAsync(requestBytes);
+    }
+
     #endregion
 }

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActorFactory.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentActorFactory.cs
@@ -1,6 +1,7 @@
 using Aevatar.Agents.Abstractions;
 using Aevatar.Agents.Abstractions.Helpers;
 using Aevatar.Agents.Core.Context;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,8 @@ namespace Aevatar.Agents.Runtime.Orleans;
 /// 
 /// Creates lightweight actor proxies that forward to Grains.
 /// Agent instances are created and executed in the Grain (Silo) side.
+/// 
+/// Uses MemoryCache with size limit and sliding expiration to avoid unbounded growth.
 /// </summary>
 public class OrleansGAgentActorFactory : IGAgentActorFactory
 {
@@ -23,6 +26,23 @@ public class OrleansGAgentActorFactory : IGAgentActorFactory
     private readonly StreamingOptions _streamingOptions;
     private readonly IMessageStreamProvider? _messageStreamProvider;
     private readonly IOptions<MessageStreamProviderOptions>? _providerOptions;
+    
+    /// <summary>
+    /// Bounded cache for actor proxies with LRU eviction via MemoryCache.
+    /// </summary>
+    private readonly MemoryCache _actorCache = new(new MemoryCacheOptions
+    {
+        SizeLimit = 10_000
+    });
+
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetSize(1)
+        .SetSlidingExpiration(TimeSpan.FromMinutes(30));
+    
+    /// <summary>
+    /// Unique identifier for this factory instance (for debugging singleton behavior)
+    /// </summary>
+    private readonly string _factoryInstanceId = Guid.NewGuid().ToString("N")[..8];
 
     public OrleansGAgentActorFactory(
         IServiceProvider serviceProvider,
@@ -36,6 +56,8 @@ public class OrleansGAgentActorFactory : IGAgentActorFactory
         _logger = logger;
         _messageStreamProvider = messageStreamProvider;
         _providerOptions = providerOptions;
+        
+        _logger.LogInformation("[ActorFactory] Created new instance: {FactoryId}", _factoryInstanceId);
 
         // Get StreamingOptions from configuration
         _streamingOptions = serviceProvider.GetService<IOptions<StreamingOptions>>()?.Value
@@ -64,18 +86,24 @@ public class OrleansGAgentActorFactory : IGAgentActorFactory
         string? id = null, 
         CancellationToken ct = default)
     {
-        // Under Orleans, ActorId must include type prefix (to avoid cross-type id conflicts):
-        // ActorId = "AgentTypeShortName:RawId"
         var inputId = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("D") : id.Trim();
         var actorId = AgentId.Normalize(agentType, inputId);
         var rawId = AgentId.ExtractRawId(actorId);
         var agentTypeName = agentType.AssemblyQualifiedName ?? agentType.FullName ?? agentType.Name;
+        
+        var agentTypeShortName = AgentId.GetAgentTypeShortName(agentTypeName);
+        var cacheKey = $"{agentTypeShortName}:{rawId}";
+        
+        // Fast path: cache hit
+        if (_actorCache.TryGetValue(cacheKey, out IGAgentActor? cachedActor) && cachedActor != null)
+        {
+            _logger.LogDebug("[ActorCache] HIT cacheKey={CacheKey}", cacheKey);
+            return cachedActor;
+        }
 
-        _logger.LogInformation(
-            "Creating Orleans Actor proxy for Agent - Type: {AgentType}, inputId={InputId}, actorId={ActorId}",
-            agentType.Name, inputId, actorId);
+        _logger.LogDebug("[ActorCache] MISS cacheKey={CacheKey} - Creating new Actor proxy for {AgentType}",
+            cacheKey, agentType.Name);
 
-        // Create lightweight actor proxy (Agent will be created in Grain/Silo)
         var contextPropagator = _serviceProvider.GetService<AgentContextPropagator>();
         var actor = new OrleansGAgentActor(
             rawId,
@@ -88,10 +116,9 @@ public class OrleansGAgentActorFactory : IGAgentActorFactory
             _providerOptions,
             contextPropagator);
 
-        // Activate - This will initialize Agent in the Grain (Silo side)
         await actor.ActivateAsync(ct);
-
-        _logger.LogInformation("✅ Created Orleans Actor proxy {ActorId}, Agent running in Silo", actor.Id);
+        
+        _actorCache.Set(cacheKey, actor, CacheEntryOptions);
 
         return actor;
     }

--- a/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/OrleansGAgentGrain.cs
@@ -73,9 +73,14 @@ public class OrleansAgentState
 /// 3. Store hierarchy relationships (Parent/Children)
 /// 4. Manage Orleans Streams subscriptions
 /// </summary>
-[Reentrant]
+// Note: Removed [Reentrant] to ensure single-threaded execution per Grain.
+// This prevents version conflicts during activation (ReplayEventsAsync must complete
+// before any other request can modify state).
 public class OrleansGAgentGrain : Grain, IGAgentGrain
 {
+    // Static shared SiloGAgentActorFactory - cached across all Grains for performance
+    private static SiloGAgentActorFactory? _sharedSiloFactory;
+    
     // Grain persistent state
     private readonly IPersistentState<OrleansAgentState> _grainState;
 
@@ -529,6 +534,9 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
         // IMPORTANT: Must inject StateStore BEFORE EventStore, as EventSourcing needs StateStore for snapshots
         AgentStateStoreInjector.InjectStateStore(agent, ServiceProvider);
 
+        // Inject EventSourcingOptions (must be before EventStore for SnapshotFrequency)
+        EventSourcingOptionsInjector.InjectEventSourcingOptions(agent, ServiceProvider);
+
         // Inject EventStore (only if agent supports EventSourcing)
         if (AgentEventStoreInjector.HasEventStore(agent))
         {
@@ -707,15 +715,42 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
         if (actorFactoryProperty == null || !actorFactoryProperty.CanWrite)
             return;
 
-        // Get IGAgentActorFactory from DI
-        var actorFactory = ServiceProvider.GetService<IGAgentActorFactory>();
-        if (actorFactory == null)
-        {
-            _logger.LogWarning("IGAgentActorFactory not registered in DI, cannot inject into Agent {AgentType}", agentType.Name);
-            return;
-        }
+        // IMPORTANT:
+        // Agent runs inside Silo. If we inject the DI-registered OrleansGAgentActorFactory (client-side),
+        // it may create client proxies (IClusterClient) which are NOT suitable for Grain-to-Grain calls.
+        //
+        // Instead, use shared SiloGAgentActorFactory that caches actor instances.
+        // First try to get from DI (if registered as Singleton), otherwise use static instance.
+        var siloFactory = GetOrCreateSharedSiloFactory();
 
-        actorFactoryProperty.SetValue(agent, actorFactory);
+        actorFactoryProperty.SetValue(agent, siloFactory);
+        _logger.LogDebug("✅ Injected SiloGAgentActorFactory into Agent {AgentType}", agentType.Name);
+    }
+    
+    /// <summary>
+    /// Get or create shared SiloGAgentActorFactory instance.
+    /// This ensures all Grains share the same factory with its actor cache.
+    /// Uses Interlocked for thread-safe lazy initialization (static field shared across Grains).
+    /// </summary>
+    private SiloGAgentActorFactory GetOrCreateSharedSiloFactory()
+    {
+        if (_sharedSiloFactory != null)
+            return _sharedSiloFactory;
+        
+        var grainFactory = ServiceProvider.GetRequiredService<IGrainFactory>();
+        var loggerFactory = ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var newFactory = new SiloGAgentActorFactory(
+            grainFactory,
+            loggerFactory.CreateLogger<SiloGAgentActorFactory>());
+        
+        // Thread-safe: if another Grain already set it, use that one (newFactory will be GC'd)
+        var existing = Interlocked.CompareExchange(ref _sharedSiloFactory, newFactory, null);
+        if (existing == null)
+        {
+            _logger.LogInformation("✅ Created shared SiloGAgentActorFactory (with cache)");
+            return newFactory;
+        }
+        return existing;
     }
 
     public Task<bool> IsInitializedAsync()
@@ -778,6 +813,102 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
             _logger.LogError(ex, "Error handling event in Grain {GrainId}", this.GetGrainId());
             throw;
         }
+    }
+
+    /// <summary>
+    /// Publish event by envelope bytes (non-blocking, via Stream).
+    /// This is used by Silo-internal actor factory to keep a single IGAgentActor API surface.
+    /// </summary>
+    public async Task<string> PublishEventAsync(
+        byte[] envelopeBytes,
+        EventDirection direction = EventDirection.Down,
+        bool isInternalCall = false)
+    {
+        if (envelopeBytes == null || envelopeBytes.Length == 0)
+        {
+            _logger.LogWarning("Received empty PublishEvent bytes in Grain {GrainId}", this.GetGrainId());
+            return string.Empty;
+        }
+
+        if (_myStream == null)
+        {
+            _logger.LogWarning("Stream not available for Grain {GrainId}, PublishEvent ignored", this.GetGrainId());
+            return string.Empty;
+        }
+
+        var envelope = EventEnvelope.Parser.ParseFrom(envelopeBytes);
+
+        // Normalize envelope fields
+        if (string.IsNullOrWhiteSpace(envelope.Id))
+            envelope.Id = Guid.NewGuid().ToString();
+
+        envelope.Direction = direction;
+        envelope.Timestamp ??= Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow);
+        envelope.CorrelationId ??= Guid.NewGuid().ToString();
+
+        // PublisherId semantics:
+        // - Internal call: keep PublisherId to prevent self-handling by default
+        // - External call: clear PublisherId so Agent can handle its own event
+        envelope.PublisherId = isInternalCall ? this.GetPrimaryKeyString() : "";
+
+        await _myStream.ProduceAsync(envelope, CancellationToken.None);
+        _logger.LogDebug("Grain {GrainId} published event {EventId} via stream, direction={Direction}",
+            this.GetGrainId(), envelope.Id, direction);
+
+        return envelope.Id;
+    }
+
+    /// <summary>
+    /// Point-to-point send by envelope bytes (non-blocking, via Stream).
+    /// This is used by Silo-internal actor factory to keep a single IGAgentActor API surface.
+    /// </summary>
+    public async Task<string> SendToAsync(
+        string targetAgentId,
+        byte[] envelopeBytes,
+        EventDirection onArrivalDirection = EventDirection.Unspecified,
+        bool isInternalCall = false)
+    {
+        if (string.IsNullOrWhiteSpace(targetAgentId))
+            throw new ArgumentException("targetAgentId cannot be empty", nameof(targetAgentId));
+
+        if (envelopeBytes == null || envelopeBytes.Length == 0)
+        {
+            _logger.LogWarning("Received empty SendTo bytes in Grain {GrainId}", this.GetGrainId());
+            return string.Empty;
+        }
+
+        if (_streamFactory == null)
+        {
+            _logger.LogWarning("StreamFactory not available in Grain {GrainId}, cannot SendTo {TargetId}",
+                this.GetGrainId(), targetAgentId);
+            return string.Empty;
+        }
+
+        var envelope = EventEnvelope.Parser.ParseFrom(envelopeBytes);
+
+        // Normalize envelope fields
+        if (string.IsNullOrWhiteSpace(envelope.Id))
+            envelope.Id = Guid.NewGuid().ToString();
+
+        envelope.TargetAgentId = targetAgentId;
+        envelope.OnArrivalDirection = onArrivalDirection;
+        envelope.Direction = onArrivalDirection;
+        envelope.Timestamp ??= Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow);
+        envelope.CorrelationId ??= Guid.NewGuid().ToString();
+
+        envelope.PublisherId = isInternalCall ? this.GetPrimaryKeyString() : "";
+
+        try
+        {
+            var targetStream = await _streamFactory.CreateStreamAsync(targetAgentId, null, this.GetStreamProvider);
+            await targetStream.ProduceAsync(envelope, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to SendTo {TargetId} from Grain {GrainId}", targetAgentId, this.GetGrainId());
+        }
+
+        return envelope.Id;
     }
 
     /// <summary>
@@ -907,7 +1038,19 @@ public class OrleansGAgentGrain : Grain, IGAgentGrain
         if (_agent == null)
             throw new InvalidOperationException("Agent not initialized");
 
-        return RpcInvoker.InvokeAsync(_agent, requestBytes, _logger, CancellationToken.None);
+        return RpcInvoker.InvokeAsync(_agent, requestBytes, _logger);
+    }
+
+    /// <summary>
+    /// Protobuf RPC method invocation for read-only operations
+    /// [AlwaysInterleave] on interface allows concurrent execution
+    /// </summary>
+    public Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes)
+    {
+        if (_agent == null)
+            throw new InvalidOperationException("Agent not initialized");
+
+        return RpcInvoker.InvokeAsync(_agent, requestBytes, _logger);
     }
 
     #endregion

--- a/src/Aevatar.Agents.Runtime.Orleans/SiloGAgentActor.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/SiloGAgentActor.cs
@@ -1,0 +1,177 @@
+using Aevatar.Agents.Abstractions;
+using Aevatar.Agents.Abstractions.Helpers;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Orleans;
+
+namespace Aevatar.Agents.Runtime.Orleans;
+
+/// <summary>
+/// Silo-side IGAgentActor implementation for Grain-to-Grain communication.
+///
+/// Goals:
+/// - Keep ONE public API for users: IGAgentActor + IGAgentActorFactory
+/// - When running inside Silo, avoid creating client proxies (IClusterClient)
+/// - Delegate all operations to the underlying IGAgentGrain
+/// </summary>
+public sealed class SiloGAgentActor : IGAgentActor
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly string _rawId;
+    private readonly string _agentTypeName;
+    private readonly ILogger _logger;
+    private IGAgentGrain? _grain;
+
+    public string Id { get; }
+
+    public SiloGAgentActor(
+        string rawId,
+        string agentTypeName,
+        IGrainFactory grainFactory,
+        ILogger logger)
+    {
+        _rawId = rawId;
+        _agentTypeName = agentTypeName;
+        _grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var agentTypeShortName = AgentId.GetAgentTypeShortName(_agentTypeName);
+        Id = string.IsNullOrWhiteSpace(agentTypeShortName)
+            ? _rawId
+            : $"{agentTypeShortName}:{_rawId}";
+    }
+
+    public async Task ActivateAsync(CancellationToken ct = default)
+    {
+        _logger.LogDebug("Activating SiloGAgentActor {ActorId}, AgentType={AgentType}", Id, _agentTypeName);
+
+        _grain = _grainFactory.GetGrain<IGAgentGrain>(Id);
+
+        var isInitialized = await _grain.IsInitializedAsync();
+        if (!isInitialized)
+        {
+            var ok = await _grain.InitializeAgentAsync(_agentTypeName);
+            if (!ok)
+                throw new InvalidOperationException($"Failed to initialize Agent {_agentTypeName} in Grain {Id}");
+        }
+    }
+
+    public async Task DeactivateAsync(CancellationToken ct = default)
+    {
+        EnsureGrain();
+        await _grain!.DeactivateAsync();
+    }
+
+    public IGAgent GetAgent()
+    {
+        // In Orleans runtime, agent lives inside Silo, no direct instance access.
+        throw new NotSupportedException("Agent instance is not available in Orleans runtime. Use RPC via As<T>() instead.");
+    }
+
+    public Task<string> GetDescriptionAsync()
+    {
+        EnsureGrain();
+        return _grain!.GetDescriptionAsync();
+    }
+
+    public Task<IReadOnlyList<string>> GetChildrenAsync()
+    {
+        EnsureGrain();
+        return _grain!.GetChildrenAsync();
+    }
+
+    public Task<string?> GetParentAsync()
+    {
+        EnsureGrain();
+        return _grain!.GetParentAsync();
+    }
+
+    public async Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+    {
+        EnsureGrain();
+
+        using var ms = new MemoryStream();
+        using var cos = new CodedOutputStream(ms);
+        envelope.WriteTo(cos);
+        cos.Flush();
+
+        await _grain!.HandleEventAsync(ms.ToArray());
+    }
+
+    public async Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
+    {
+        EnsureGrain();
+        return await _grain!.InvokeRpcAsync(requestBytes);
+    }
+
+    public async Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes)
+    {
+        EnsureGrain();
+        return await _grain!.InvokeReadOnlyRpcAsync(requestBytes);
+    }
+
+    public async Task<string> PublishEventAsync<TEvent>(
+        TEvent evt,
+        EventDirection direction = EventDirection.Down,
+        CancellationToken ct = default,
+        bool isInternalCall = false)
+        where TEvent : IMessage
+    {
+        EnsureGrain();
+
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString(),
+            PublisherId = isInternalCall ? Id : "",
+            Payload = Google.Protobuf.WellKnownTypes.Any.Pack(evt),
+            Direction = direction,
+            Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow),
+            CorrelationId = Guid.NewGuid().ToString()
+        };
+
+        using var ms = new MemoryStream();
+        using var cos = new CodedOutputStream(ms);
+        envelope.WriteTo(cos);
+        cos.Flush();
+
+        return await _grain!.PublishEventAsync(ms.ToArray(), direction, isInternalCall);
+    }
+
+    public async Task<string> SendToAsync<TEvent>(
+        string targetAgentId,
+        TEvent evt,
+        EventDirection onArrivalDirection = EventDirection.Unspecified,
+        CancellationToken ct = default,
+        bool isInternalCall = false)
+        where TEvent : IMessage
+    {
+        EnsureGrain();
+
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString(),
+            PublisherId = isInternalCall ? Id : "",
+            Payload = Google.Protobuf.WellKnownTypes.Any.Pack(evt),
+            Direction = onArrivalDirection,
+            Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow),
+            CorrelationId = Guid.NewGuid().ToString(),
+            TargetAgentId = targetAgentId,
+            OnArrivalDirection = onArrivalDirection
+        };
+
+        using var ms = new MemoryStream();
+        using var cos = new CodedOutputStream(ms);
+        envelope.WriteTo(cos);
+        cos.Flush();
+
+        return await _grain!.SendToAsync(targetAgentId, ms.ToArray(), onArrivalDirection, isInternalCall);
+    }
+
+    private void EnsureGrain()
+    {
+        if (_grain == null)
+            throw new InvalidOperationException("Actor not activated. Call ActivateAsync first.");
+    }
+}
+
+

--- a/src/Aevatar.Agents.Runtime.Orleans/SiloGAgentActorFactory.cs
+++ b/src/Aevatar.Agents.Runtime.Orleans/SiloGAgentActorFactory.cs
@@ -1,0 +1,67 @@
+using Aevatar.Agents.Abstractions;
+using Aevatar.Agents.Abstractions.Helpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Orleans;
+
+namespace Aevatar.Agents.Runtime.Orleans;
+
+/// <summary>
+/// Silo-side IGAgentActorFactory implementation (for OrleansGrain internal use).
+/// Creates <see cref="SiloGAgentActor"/> which delegates to <see cref="IGAgentGrain"/> via <see cref="IGrainFactory"/>.
+/// Uses MemoryCache with size limit and sliding expiration to avoid unbounded growth.
+/// </summary>
+public sealed class SiloGAgentActorFactory : IGAgentActorFactory
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILogger<SiloGAgentActorFactory> _logger;
+    
+    /// <summary>
+    /// Bounded cache for actor instances with LRU eviction via MemoryCache.
+    /// </summary>
+    private readonly MemoryCache _actorCache = new(new MemoryCacheOptions
+    {
+        SizeLimit = 10_000
+    });
+
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetSize(1)
+        .SetSlidingExpiration(TimeSpan.FromMinutes(30));
+
+    public SiloGAgentActorFactory(IGrainFactory grainFactory, ILogger<SiloGAgentActorFactory> logger)
+    {
+        _grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IGAgentActor> CreateGAgentActorAsync<TAgent>(string? id = null, CancellationToken ct = default)
+        where TAgent : IGAgent
+    {
+        var agentType = typeof(TAgent);
+        var inputId = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("D") : id.Trim();
+
+        var actorId = AgentId.Normalize(agentType, inputId);
+        var rawId = AgentId.ExtractRawId(actorId);
+        var agentTypeName = agentType.AssemblyQualifiedName ?? agentType.FullName ?? agentType.Name;
+        
+        var agentTypeShortName = AgentId.GetAgentTypeShortName(agentTypeName);
+        var cacheKey = $"{agentTypeShortName}:{rawId}";
+        
+        // Fast path: cache hit
+        if (_actorCache.TryGetValue(cacheKey, out IGAgentActor? cachedActor) && cachedActor != null)
+        {
+            _logger.LogDebug("[SiloActorCache] HIT cacheKey={CacheKey}", cacheKey);
+            return cachedActor;
+        }
+
+        _logger.LogDebug("[SiloActorCache] MISS cacheKey={CacheKey} - Creating SiloGAgentActor for {AgentType}",
+            cacheKey, agentType.Name);
+
+        var actor = new SiloGAgentActor(rawId, agentTypeName, _grainFactory, _logger);
+        await actor.ActivateAsync(ct);
+        
+        _actorCache.Set(cacheKey, actor, CacheEntryOptions);
+        
+        return actor;
+    }
+}

--- a/test/Aevatar.Agents.AGUI.Tests/AgUiBootstrapTests.cs
+++ b/test/Aevatar.Agents.AGUI.Tests/AgUiBootstrapTests.cs
@@ -108,6 +108,8 @@ public class AgUiBootstrapTests
             bool isInternalCall = false) where TEvent : IMessage
             => Task.FromResult(string.Empty);
 
+        public Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes) => InvokeRpcAsync(requestBytes);
+
         public Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
         {
             var req = RpcRequest.Parser.ParseFrom(requestBytes);

--- a/test/Aevatar.Agents.Abstractions.Tests/RpcExtensionsTests.cs
+++ b/test/Aevatar.Agents.Abstractions.Tests/RpcExtensionsTests.cs
@@ -54,6 +54,8 @@ public class RpcExtensionsTests
             bool isInternalCall = false) where TEvent : IMessage
             => throw new NotSupportedException();
 
+        public Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes) => InvokeRpcAsync(requestBytes);
+
         public Task<byte[]> InvokeRpcAsync(byte[] requestBytes)
         {
             InvokeRpcCalled = true;

--- a/test/Aevatar.Agents.Runtime.Tests/GAgentActorFactoryBaseTests.cs
+++ b/test/Aevatar.Agents.Runtime.Tests/GAgentActorFactoryBaseTests.cs
@@ -76,6 +76,7 @@ public class GAgentActorFactoryBaseTests
         }
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<byte[]> InvokeRpcAsync(byte[] requestBytes) => Task.FromResult(Array.Empty<byte>());
+        public Task<byte[]> InvokeReadOnlyRpcAsync(byte[] requestBytes) => InvokeRpcAsync(requestBytes);
         public Task<string> PublishEventAsync<TEvent>(TEvent evt, EventDirection direction = EventDirection.Down,
             CancellationToken ct = default, bool isInternalCall = false) where TEvent : IMessage
             => Task.FromResult(string.Empty);


### PR DESCRIPTION
- ProtobufEventTypeResolver: restore cross-assembly scanning, FullName matching for multi-module deployment
- ReflectionEventHandlerDiscoverer: restore inheritance chain traversal with GetBaseDefinition() deduplication
- MassTransit: extract GodGPT-specific trace logic to pluggable ITraceIdExtractor interface
- RpcInvoker: propagate CancellationToken to reflected method parameters
- SiloGAgentActorFactory/OrleansGAgentActorFactory: add MemoryCache (SizeLimit 10K, SlidingExpiration 30min)
- Add ReadOnly RPC, SiloGAgentActor, EventSourcing options 