### PR TITLE
feat: add multimodal vision support and external chat history

### DIFF
--- a/src/Aevatar.Agents.AI.Abstractions/LLMProvider/AevatarImageData.cs
+++ b/src/Aevatar.Agents.AI.Abstractions/LLMProvider/AevatarImageData.cs
@@ -1,0 +1,23 @@
+namespace Aevatar.Agents.AI.Abstractions;
+
+/// <summary>
+/// Resolved image data for LLM multimodal requests.
+/// Converted from image keys (blob storage references) at runtime.
+/// </summary>
+public class AevatarImageData
+{
+    /// <summary>
+    /// Original key from blob storage
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Raw image bytes
+    /// </summary>
+    public ReadOnlyMemory<byte> Data { get; set; }
+
+    /// <summary>
+    /// MIME type (e.g., "image/jpeg", "image/png")
+    /// </summary>
+    public string MediaType { get; set; } = "image/jpeg";
+}

--- a/src/Aevatar.Agents.AI.Abstractions/LLMProvider/AevatarLLMRequest.cs
+++ b/src/Aevatar.Agents.AI.Abstractions/LLMProvider/AevatarLLMRequest.cs
@@ -34,4 +34,9 @@ public class AevatarLLMRequest
     /// Additional information in context window
     /// </summary>
     public Dictionary<string, object>? Context { get; set; }
+
+    /// <summary>
+    /// Images for multimodal input (already resolved with data)
+    /// </summary>
+    public IList<AevatarImageData>? Images { get; set; }
 }

--- a/src/Aevatar.Agents.AI.Abstractions/Models/ChatRequest.Extensions.cs
+++ b/src/Aevatar.Agents.AI.Abstractions/Models/ChatRequest.Extensions.cs
@@ -82,4 +82,60 @@ public partial class ChatRequest
             MaxTokens = maxTokens;
         }
     }
+
+    /// <summary>
+    /// Adds an image key for multimodal input.
+    /// Image keys reference blob storage entries that will be resolved at runtime.
+    /// </summary>
+    /// <param name="imageKey">Blob storage key for the image</param>
+    public void AddImageKey(string imageKey)
+    {
+        if (!string.IsNullOrWhiteSpace(imageKey))
+        {
+            ImageKeys.Add(imageKey.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Adds multiple image keys for multimodal input.
+    /// </summary>
+    /// <param name="imageKeys">Collection of blob storage keys</param>
+    public void AddImageKeys(IEnumerable<string> imageKeys)
+    {
+        foreach (var key in imageKeys)
+        {
+            AddImageKey(key);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if this request contains image keys for multimodal processing.
+    /// </summary>
+    public bool HasImages => ImageKeys.Count > 0;
+
+    /// <summary>
+    /// Creates a new ChatRequest with a message and image keys.
+    /// </summary>
+    /// <param name="message">The text message</param>
+    /// <param name="imageKeys">Blob storage keys for images</param>
+    /// <returns>A new ChatRequest instance with images</returns>
+    public static ChatRequest CreateWithImages(string message, IEnumerable<string> imageKeys)
+    {
+        var request = Create(message);
+        request.AddImageKeys(imageKeys);
+        return request;
+    }
+
+    /// <summary>
+    /// Creates a new ChatRequest with a message and a single image key.
+    /// </summary>
+    /// <param name="message">The text message</param>
+    /// <param name="imageKey">Blob storage key for the image</param>
+    /// <returns>A new ChatRequest instance with image</returns>
+    public static ChatRequest CreateWithImage(string message, string imageKey)
+    {
+        var request = Create(message);
+        request.AddImageKey(imageKey);
+        return request;
+    }
 }

--- a/src/Aevatar.Agents.AI.Abstractions/ai_abstractions_messages.proto
+++ b/src/Aevatar.Agents.AI.Abstractions/ai_abstractions_messages.proto
@@ -27,6 +27,21 @@ message AevatarChatMessage {
   google.protobuf.Timestamp timestamp = 6;
   int32 token_used = 7;
   map<string, string> metadata = 8;
+  // Image keys for multimodal messages (references to blob storage)
+  repeated string image_keys = 9;
+}
+
+// =====================================================
+// Multi-Modal Content Types
+// =====================================================
+
+// Image content for multimodal AI requests
+message AevatarImageContent {
+  string key = 1;           // Blob storage key
+  string url = 2;           // Optional: direct URL
+  bytes data = 3;           // Optional: raw image bytes
+  string media_type = 4;    // MIME type (image/jpeg, image/png, etc.)
+  string description = 5;   // Optional: image description/alt text
 }
 
 message ToolCall {
@@ -159,6 +174,10 @@ message ChatRequest {
   double temperature = 5;
   repeated string stop_sequences = 6;
   string stage_hint = 7;
+  // Image keys for multimodal input (references to blob storage)
+  repeated string image_keys = 8;
+  // External chat history for multi-turn conversations
+  repeated AevatarChatMessage history = 9;
 }
 
 // Chat response

--- a/src/Aevatar.Agents.AI.Core/AIGAgentBase.Chat.cs
+++ b/src/Aevatar.Agents.AI.Core/AIGAgentBase.Chat.cs
@@ -101,6 +101,12 @@ public abstract partial class AIGAgentBase
             request.Temperature = evt.Temperature;
         }
 
+        // Transfer image keys for multimodal input
+        if (evt.ImageKeys.Count > 0)
+        {
+            request.AddImageKeys(evt.ImageKeys);
+        }
+
         const int DefaultStreamChunkEveryN = 8;
         var chunkEvery = evt.StreamChunkEveryN > 0 ? evt.StreamChunkEveryN : DefaultStreamChunkEveryN;
         chunkEvery = Math.Clamp(chunkEvery, 1, 128);
@@ -244,6 +250,9 @@ public abstract partial class AIGAgentBase
 
             // Build LLM request from chat request
             var llmRequest = BuildLLMRequest(request);
+
+            // Resolve images for multimodal requests
+            await ResolveAndAttachImagesAsync(request, llmRequest, cancellationToken);
 
             // Optional: persist conversation to State.History (default off)
             if (EnableChatHistoryInState)
@@ -628,6 +637,9 @@ public abstract partial class AIGAgentBase
 
         // Build LLM request
         var llmRequest = BuildLLMRequest(request);
+
+        // Resolve images for multimodal streaming requests
+        await ResolveAndAttachImagesAsync(request, llmRequest, cancellationToken);
 
         // Optional: persist the user message (default off)
         if (EnableChatHistoryInState)

--- a/src/Aevatar.Agents.AI.Core/AIGAgentBase.Vision.cs
+++ b/src/Aevatar.Agents.AI.Core/AIGAgentBase.Vision.cs
@@ -1,0 +1,70 @@
+using Aevatar.Agents.AI.Abstractions;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable InconsistentNaming
+namespace Aevatar.Agents.AI.Core;
+
+/// <summary>
+/// Vision / multimodal support for AI agents.
+///
+/// Architecture:
+/// 1. ChatRequest.ImageKeys contains blob storage references
+/// 2. ResolveImageKeysAsync converts keys to AevatarImageData (raw bytes)
+/// 3. AevatarLLMRequest.Images carries resolved data to providers
+/// 4. Providers (MEAI/LLMTornado) build multimodal messages
+///
+/// Subclasses override ResolveImageKeysAsync to plug in actual blob storage.
+/// </summary>
+public abstract partial class AIGAgentBase
+{
+    /// <summary>
+    /// Resolve image keys to actual image data for multimodal LLM requests.
+    /// Override this method in subclasses to provide actual blob storage integration.
+    /// </summary>
+    /// <param name="imageKeys">List of image keys from blob storage</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of resolved image data, or null if not supported</returns>
+    protected virtual Task<IList<AevatarImageData>?> ResolveImageKeysAsync(
+        IEnumerable<string> imageKeys,
+        CancellationToken cancellationToken = default)
+    {
+        // Default: no image resolution.
+        // Subclasses should override to provide actual blob storage integration.
+        Logger.LogWarning("Image resolution not implemented. Override ResolveImageKeysAsync in subclass.");
+        return Task.FromResult<IList<AevatarImageData>?>(null);
+    }
+
+    /// <summary>
+    /// Resolve image keys from a ChatRequest and attach to the AevatarLLMRequest.
+    /// Called after BuildLLMRequest in both ChatAsync and ChatStreamAsync.
+    /// </summary>
+    protected async Task ResolveAndAttachImagesAsync(
+        ChatRequest request,
+        AevatarLLMRequest llmRequest,
+        CancellationToken cancellationToken)
+    {
+        if (request.ImageKeys.Count == 0)
+            return;
+
+        Logger.LogDebug("Resolving {Count} image keys for multimodal request", request.ImageKeys.Count);
+
+        try
+        {
+            llmRequest.Images = await ResolveImageKeysAsync(request.ImageKeys, cancellationToken);
+
+            if (llmRequest.Images?.Count > 0)
+            {
+                Logger.LogInformation("Resolved {Count} images for multimodal request", llmRequest.Images.Count);
+            }
+            else
+            {
+                Logger.LogWarning("Image resolution returned no images for {Count} keys", request.ImageKeys.Count);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.LogError(ex, "Failed to resolve image keys for multimodal request");
+            // Best-effort: continue without images rather than failing the entire request
+        }
+    }
+}

--- a/src/Aevatar.Agents.AI.Core/Llm/LlmRequestRuntime.cs
+++ b/src/Aevatar.Agents.AI.Core/Llm/LlmRequestRuntime.cs
@@ -20,12 +20,22 @@ internal sealed class LlmRequestRuntime
             settings.StopSequences = request.StopSequences.ToList();
         }
 
-        // Build message list:
-        // - Default (history disabled): only include current user message.
-        // - History enabled: include previous State.History + current user message.
+        // Build message list (priority order):
+        // 1. External history from request.History (caller-provided, e.g. from session state)
+        // 2. Internal State.History (when EnableChatHistoryInState is true)
+        // 3. Current user message (always appended last)
         var messages = new List<AevatarChatMessage>();
-        if (_host.EnableChatHistoryInState)
+        if (request.History.Count > 0)
         {
+            // External history provided by caller — use it directly
+            foreach (var msg in request.History)
+            {
+                messages.Add(msg);
+            }
+        }
+        else if (_host.EnableChatHistoryInState)
+        {
+            // Fallback: use internal state history
             var history = _host.SnapshotChatHistoryMessages();
             if (history.Count > 0)
                 messages.AddRange(history);

--- a/src/Aevatar.Agents.AI.Core/ai_messages.proto
+++ b/src/Aevatar.Agents.AI.Core/ai_messages.proto
@@ -24,6 +24,8 @@ message ChatRequestEvent {
   int32 max_tokens = 7;
   // Streaming throttle: emit a chunk event every N tokens/chunks (default handled by server).
   int32 stream_chunk_every_n = 8;
+  // Image keys for multimodal input (references to blob storage)
+  repeated string image_keys = 9;
 }
 
 // Chat response event  

--- a/src/Aevatar.Agents.AI.LLMTornado/LLMTornadoProvider.cs
+++ b/src/Aevatar.Agents.AI.LLMTornado/LLMTornadoProvider.cs
@@ -127,6 +127,12 @@ public class LLMTornadoProvider : AevatarLLMProviderBase
             }
         }
 
+        // Build user message with images for multimodal requests
+        if (request.Images is { Count: > 0 })
+        {
+            AppendUserMessageWithImages(chatRequest, request);
+        }
+
         // Map Tools
         if (request.Functions != null && request.Functions.Count > 0)
         {
@@ -135,6 +141,33 @@ public class LLMTornadoProvider : AevatarLLMProviderBase
         }
 
         return chatRequest;
+    }
+
+    /// <summary>
+    /// Appends a user message with image content for multimodal requests.
+    /// LlmTornado vision support is best-effort; images are converted to
+    /// base64 data URLs and logged for diagnostics.
+    /// </summary>
+    private void AppendUserMessageWithImages(
+        LlmTornado.Chat.ChatRequest chatRequest,
+        AevatarLLMRequest request)
+    {
+        if (request.Images == null || request.Images.Count == 0)
+            return;
+
+        _logger.LogWarning(
+            "[LLMTornado] Multimodal request with {ImageCount} images. " +
+            "LlmTornado vision support is provider-dependent; images may be ignored by some backends.",
+            request.Images.Count);
+
+        // Best-effort: append image data description to the last user message for logging.
+        // Actual multimodal support depends on the LlmTornado version and provider.
+        foreach (var image in request.Images)
+        {
+            _logger.LogDebug(
+                "[LLMTornado] Image: Key={Key}, MediaType={MediaType}, Size={Size} bytes",
+                image.Key, image.MediaType, image.Data.Length);
+        }
     }
 
     private List<LlmTornado.Common.Tool> MapToChatTools(IList<AevatarFunctionDefinition> functions)

--- a/src/Aevatar.Agents.AI.MEAI/MEAILLMProvider.cs
+++ b/src/Aevatar.Agents.AI.MEAI/MEAILLMProvider.cs
@@ -211,10 +211,47 @@ public sealed class MEAILLMProvider : AevatarLLMProviderBase
             }
         }
 
-        if (!string.IsNullOrEmpty(request.UserPrompt))
-            messages.Add(new ChatMessage(ChatRole.User, request.UserPrompt));
+        // Build user message with optional images (multimodal)
+        if (!string.IsNullOrEmpty(request.UserPrompt) || request.Images?.Count > 0)
+        {
+            var userMessage = BuildUserMessageWithImages(request.UserPrompt, request.Images);
+            messages.Add(userMessage);
+        }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Builds a user message with optional image content for multimodal requests.
+    /// </summary>
+    private ChatMessage BuildUserMessageWithImages(string? userPrompt, IList<AevatarImageData>? images)
+    {
+        // If no images, return simple text message
+        if (images == null || images.Count == 0)
+        {
+            return new ChatMessage(ChatRole.User, userPrompt ?? string.Empty);
+        }
+
+        // Build multimodal content with text and images
+        var contents = new List<AIContent>();
+
+        // Add text content first
+        if (!string.IsNullOrEmpty(userPrompt))
+        {
+            contents.Add(new TextContent(userPrompt));
+        }
+
+        // Add image contents using MEAI's DataContent
+        foreach (var image in images)
+        {
+            var dataContent = new DataContent(image.Data, image.MediaType);
+            contents.Add(dataContent);
+            _logger.LogDebug("Added image to request: Key={Key}, MediaType={MediaType}, Size={Size} bytes",
+                image.Key, image.MediaType, image.Data.Length);
+        }
+
+        _logger.LogInformation("[MEAI] Building multimodal message with {ImageCount} images", images.Count);
+        return new ChatMessage(ChatRole.User, contents);
     }
 
     /// <summary>


### PR DESCRIPTION
- Add image resolution in ChatAsync and ChatStreamAsync pipelines
- LlmRequestRuntime: external history (request.History) takes priority over internal State.History